### PR TITLE
Profil commercialisateur

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,87 @@
+# Boris
+
+Boris helps households understand Bail Reel Solidaire eligibility and connects eligible contacts with the organizations that can support or sell BRS homes.
+
+## Language
+
+**OFS**:
+An Organisme de Foncier Solidaire that can receive and manage eligible household contacts.
+_Avoid_: Portal user, seller
+
+**Compte OFS**:
+A portal user account attached to one or more OFS.
+_Avoid_: OFS, commercialisateur
+
+**Commercialisateur**:
+An organization in charge of marketing or selling BRS houses or apartments on behalf of an OFS.
+_Avoid_: Compte commercialisateur, OFS
+
+**Compte commercialisateur**:
+A portal user account belonging to a commercialisateur.
+_Avoid_: Commercialisateur, compte OFS
+
+**Transmission commerciale**:
+An OFS-defined relationship that makes selected household contacts visible to a commercialisateur.
+_Avoid_: Mandat commercial, accès OFS
+
+**Périmètre de transmission**:
+The rule that determines which contacts are included in a transmission commerciale.
+_Avoid_: Accès, filtre
+
+**Ligne de contact**:
+A contact record for one searched location within an eligibility simulation.
+_Avoid_: Lead, simulation
+
+**Suivi commercialisateur**:
+The follow-up metadata managed by a commercialisateur for a transmitted contact line.
+_Avoid_: Suivi OFS, statut OFS
+
+## Relationships
+
+- An **OFS** can work with zero or more **Commercialisateurs**
+- A **Commercialisateur** can work with one or more **OFS**
+- A **Compte commercialisateur** belongs to exactly one **Commercialisateur**
+- A **Commercialisateur** can have one or more **Comptes commercialisateur**
+- All **Comptes commercialisateur** of the same **Commercialisateur** inherit the same transmitted contact access
+- An **OFS** can define zero or more **Transmissions commerciales**
+- A **Transmission commerciale** links exactly one **OFS** to exactly one **Commercialisateur**
+- A **Transmission commerciale** adds access for a **Commercialisateur** without removing access from the **OFS**
+- Several **Transmissions commerciales** can include the same contact
+- A **Transmission commerciale** has exactly one **Périmètre de transmission**
+- A **Périmètre de transmission** is either all contact lines visible to the **OFS**, or contact lines matching selected INSEE commune codes or department codes
+- An INSEE-or-department **Périmètre de transmission** applies at the **Ligne de contact** level
+- A **Ligne de contact** matches an INSEE-or-department **Périmètre de transmission** when its INSEE commune code or department code is selected
+- A **Transmission commerciale** can only include **Lignes de contact** already visible to its **OFS**
+- A **Compte commercialisateur** can view and export transmitted **Lignes de contact**
+- A **Compte commercialisateur** dashboard groups transmitted **Lignes de contact** by **OFS**
+- A **Compte commercialisateur** dashboard shows every **OFS** with an active **Transmission commerciale**, even when no contact lines currently match
+- Inactive **Transmissions commerciales** are hidden from the **Compte commercialisateur** dashboard in the first version
+- A **Compte commercialisateur** can see limited read-only **OFS** identity and contact details, but cannot manage the **OFS**
+- A **Compte commercialisateur** manages **Suivi commercialisateur** separately from OFS follow-up metadata
+- **Comptes OFS** and **Comptes commercialisateur** use the same portal application with role-specific sections
+- In the first version, portal accounts have exactly one role; **Compte OFS** and **Compte commercialisateur** roles are mutually exclusive
+- A **Compte commercialisateur** can log in even when its **Commercialisateur** has no active **Transmissions commerciales**
+- In the first version, a **Transmission commerciale** creates dashboard and export visibility, not email notification
+- An **OFS** can see which **Commercialisateurs** received a **Ligne de contact**, without managing their **Suivi commercialisateur**
+- A **Compte OFS** can configure **Transmissions commerciales** for its **OFS**
+- A **Compte OFS** can configure **Transmissions commerciales** for every **OFS** it can access
+- A **Compte OFS** can create a **Transmission commerciale** only to a **Commercialisateur** already linked to that **OFS**
+- An **OFS** can have at most one **Transmission commerciale** for a given **Commercialisateur**
+- An INSEE-or-department **Transmission commerciale** can include several INSEE commune codes or department codes and is edited when its list changes
+- A **Transmission commerciale** is deactivated rather than hard-deleted
+- An inactive **Transmission commerciale** gives no contact-line visibility to the **Commercialisateur**
+- Contact-line visibility for a **Commercialisateur** is always computed from the current active **Transmission commerciale** scope
+- In the first version, admins create **Commercialisateurs** and **Comptes commercialisateur**
+- Admin user management creates **Comptes commercialisateur** by assigning exactly one **Commercialisateur**
+- In the first version, **Comptes OFS** configure transmission rules but do not create **Commercialisateurs**, **Comptes commercialisateur**, or OFS-Commercialisateur links
+- Audit trail for **Transmission commerciale** changes is deferred from the first version
+
+## Example dialogue
+
+> **Dev:** "Should this **Commercialisateur** see every contact for the OFS?"
+> **Domain expert:** "No, its **Comptes commercialisateur** should only see the contacts transmitted to that **Commercialisateur**."
+
+## Flagged ambiguities
+
+- "commercialisateur" was used to mean both the selling organization and the portal user profile; resolved: the organization is **Commercialisateur**, while the portal user is **Compte commercialisateur**.
+- Existing code may use `Distributor` for **Commercialisateur**, but the portal role value should remain `commercialisateur`.

--- a/apps/backend/src/application/eligibility-simulation/usecases/find-portal-contact-lines.usecase.ts
+++ b/apps/backend/src/application/eligibility-simulation/usecases/find-portal-contact-lines.usecase.ts
@@ -44,6 +44,16 @@ export class FindPortalContactLinesUsecase {
       propertySituation: this.propertySituationLabel(item.propertySituation),
       housingType: item.housingType,
       isNew: compareDate ? new Date(item.submittedAt) > compareDate : false,
+      transmittedDistributors: item.transmittedDistributors || [],
+      ofs: item.ofsId
+        ? {
+            id: item.ofsId,
+            name: item.ofsName || '',
+            email: item.ofsEmail || null,
+            phone: item.ofsPhone || null,
+            websiteUrl: item.ofsWebsiteUrl || null,
+          }
+        : null,
     } as PortalContactLineView);
   }
 

--- a/apps/backend/src/application/eligibility-simulation/views/portal-contact-line.view.ts
+++ b/apps/backend/src/application/eligibility-simulation/views/portal-contact-line.view.ts
@@ -17,6 +17,14 @@ export class PortalContactLineView {
   public action: string | null;
   public status: string | null;
   public isNew: boolean;
+  public transmittedDistributors: { id: string; name: string }[];
+  public ofs: {
+    id: string;
+    name: string;
+    email: string | null;
+    phone: string | null;
+    websiteUrl: string | null;
+  } | null;
 
   constructor(props: PortalContactLineView) {
     this.simulationId = props.simulationId;
@@ -37,5 +45,7 @@ export class PortalContactLineView {
     this.action = props.action;
     this.status = props.status;
     this.isNew = props.isNew;
+    this.transmittedDistributors = props.transmittedDistributors || [];
+    this.ofs = props.ofs || null;
   }
 }

--- a/apps/backend/src/application/user/usecases/create-managed-user.params.ts
+++ b/apps/backend/src/application/user/usecases/create-managed-user.params.ts
@@ -4,4 +4,5 @@ export interface CreateManagedUserParams {
   email: string;
   role: UserRole;
   ofsIds?: string[];
+  distributorId?: string;
 }

--- a/apps/backend/src/application/user/usecases/create-managed-user.usecase.ts
+++ b/apps/backend/src/application/user/usecases/create-managed-user.usecase.ts
@@ -13,6 +13,7 @@ import { CreateManagedUserParams } from './create-managed-user.params';
 import { normalizeEmail } from '../utils/normalize-email';
 import { UserRole } from 'src/domain/user/user-role.enum';
 import { OfsEntity } from 'src/infrastructure/ofs/ofs.entity';
+import { DistributorEntity } from 'src/infrastructure/distributor/distributor.entity';
 import { generateTemporaryPassword } from '../utils/generate-temporary-password';
 import { In } from 'typeorm';
 
@@ -25,6 +26,8 @@ export class CreateManagedUserUsecase {
     private readonly passwordHasher: PasswordHasherInterface,
     @InjectRepository(OfsEntity)
     private readonly ofsRepository: Repository<OfsEntity>,
+    @InjectRepository(DistributorEntity)
+    private readonly distributorRepository: Repository<DistributorEntity>,
   ) {}
 
   public async execute(params: CreateManagedUserParams): Promise<{
@@ -42,14 +45,41 @@ export class CreateManagedUserUsecase {
     }
 
     const ofss = await this.resolveOfss(role, ofsIds);
+    const distributor = await this.resolveDistributor(
+      role,
+      params.distributorId,
+    );
     const generatedPassword = generateTemporaryPassword();
     const hashedPassword = await this.passwordHasher.hash(generatedPassword);
 
     const user = await this.userRepository.save(
-      new UserEntity(email, hashedPassword, [role], true, ofss),
+      new UserEntity(email, hashedPassword, [role], true, ofss, distributor),
     );
 
     return { user, generatedPassword };
+  }
+
+  private async resolveDistributor(
+    role: UserRole,
+    distributorId?: string,
+  ): Promise<DistributorEntity | null> {
+    if (role !== UserRole.DISTRIBUTOR) {
+      return null;
+    }
+
+    if (!distributorId) {
+      throw new BadRequestException();
+    }
+
+    const distributor = await this.distributorRepository.findOneBy({
+      id: distributorId,
+    });
+
+    if (!distributor) {
+      throw new BadRequestException();
+    }
+
+    return distributor;
   }
 
   private normalizeIds(ids?: string[]): string[] {

--- a/apps/backend/src/application/user/usecases/findAll.usecase.ts
+++ b/apps/backend/src/application/user/usecases/findAll.usecase.ts
@@ -34,6 +34,9 @@ export class FindAllUsersUsecase {
             user.ofss
               .map((ofs) => ({ id: ofs.id, name: ofs.name }))
               .sort((left, right) => left.name.localeCompare(right.name, 'fr')),
+            user.distributor
+              ? { id: user.distributor.id, name: user.distributor.name }
+              : null,
             user.lastLoginAt || null,
           ),
       ),

--- a/apps/backend/src/application/user/usecases/findById.usecase.ts
+++ b/apps/backend/src/application/user/usecases/findById.usecase.ts
@@ -24,6 +24,9 @@ export class FindUserByIdUsecase {
       user.ofss
         .map((ofs) => ({ id: ofs.id, name: ofs.name }))
         .sort((left, right) => left.name.localeCompare(right.name, 'fr')),
+      user.distributor
+        ? { id: user.distributor.id, name: user.distributor.name }
+        : null,
       user.lastLoginAt || null,
       user.createdAt,
       user.updatedAt,

--- a/apps/backend/src/application/user/usecases/update-managed-user.params.ts
+++ b/apps/backend/src/application/user/usecases/update-managed-user.params.ts
@@ -6,4 +6,5 @@ export interface UpdateManagedUserParams {
   email: string;
   role: UserRole;
   ofsIds?: string[];
+  distributorId?: string;
 }

--- a/apps/backend/src/application/user/usecases/update-managed-user.usecase.ts
+++ b/apps/backend/src/application/user/usecases/update-managed-user.usecase.ts
@@ -13,6 +13,7 @@ import { UpdateManagedUserParams } from './update-managed-user.params';
 import { normalizeEmail } from '../utils/normalize-email';
 import { UserRole } from 'src/domain/user/user-role.enum';
 import { OfsEntity } from 'src/infrastructure/ofs/ofs.entity';
+import { DistributorEntity } from 'src/infrastructure/distributor/distributor.entity';
 import { UserSessionService } from 'src/infrastructure/session/user-session.service';
 import { In } from 'typeorm';
 
@@ -23,6 +24,8 @@ export class UpdateManagedUserUsecase {
     private readonly userRepository: UserRepositoryInterface,
     @InjectRepository(OfsEntity)
     private readonly ofsRepository: Repository<OfsEntity>,
+    @InjectRepository(DistributorEntity)
+    private readonly distributorRepository: Repository<DistributorEntity>,
     private readonly userSessionService: UserSessionService,
   ) {}
 
@@ -68,6 +71,10 @@ export class UpdateManagedUserUsecase {
     }
 
     const nextOfss = await this.resolveOfss(nextRole, ofsIds);
+    const nextDistributor = await this.resolveDistributor(
+      nextRole,
+      params.distributorId,
+    );
     const nextRoles = [nextRole];
     const hadSameEmail = user.email === nextEmail;
     const hadSameRole = user.roles.length === 1 && user.roles[0] === nextRole;
@@ -75,20 +82,45 @@ export class UpdateManagedUserUsecase {
       user.ofss.map((ofs) => ofs.id),
       nextOfss.map((ofs) => ofs.id),
     );
+    const hadSameDistributor = user.distributor?.id === nextDistributor?.id;
 
     user.email = nextEmail;
     user.roles = nextRoles;
     user.ofss = nextOfss;
+    user.distributor = nextDistributor;
 
     await this.userRepository.save(user);
 
-    if (!hadSameEmail || !hadSameRole || !hadSameOfss) {
+    if (!hadSameEmail || !hadSameRole || !hadSameOfss || !hadSameDistributor) {
       await this.userSessionService.destroyAllForUserId(user.id);
     }
   }
 
   private normalizeIds(ids?: string[]): string[] {
     return Array.from(new Set((ids || []).filter(Boolean)));
+  }
+
+  private async resolveDistributor(
+    role: UserRole,
+    distributorId?: string,
+  ): Promise<DistributorEntity | null> {
+    if (role !== UserRole.DISTRIBUTOR) {
+      return null;
+    }
+
+    if (!distributorId) {
+      throw new BadRequestException();
+    }
+
+    const distributor = await this.distributorRepository.findOneBy({
+      id: distributorId,
+    });
+
+    if (!distributor) {
+      throw new BadRequestException();
+    }
+
+    return distributor;
   }
 
   private async resolveOfss(

--- a/apps/backend/src/application/user/views/admin-user-detail.view.ts
+++ b/apps/backend/src/application/user/views/admin-user-detail.view.ts
@@ -6,6 +6,7 @@ export class AdminUserDetailView {
   public roles: UserRole[];
   public isActive: boolean;
   public ofss: { id: string; name: string }[];
+  public distributor: { id: string; name: string } | null;
   public lastLoginAt: Date | null;
   public createdAt: Date;
   public updatedAt: Date;
@@ -16,6 +17,7 @@ export class AdminUserDetailView {
     roles: UserRole[],
     isActive: boolean,
     ofss: { id: string; name: string }[],
+    distributor: { id: string; name: string } | null,
     lastLoginAt: Date | null,
     createdAt: Date,
     updatedAt: Date,
@@ -25,6 +27,7 @@ export class AdminUserDetailView {
     this.roles = roles;
     this.isActive = isActive;
     this.ofss = ofss;
+    this.distributor = distributor;
     this.lastLoginAt = lastLoginAt;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;

--- a/apps/backend/src/application/user/views/admin-user-list-item.view.ts
+++ b/apps/backend/src/application/user/views/admin-user-list-item.view.ts
@@ -6,6 +6,7 @@ export class AdminUserListItemView {
   public roles: UserRole[];
   public isActive: boolean;
   public ofss: { id: string; name: string }[];
+  public distributor: { id: string; name: string } | null;
   public lastLoginAt: Date | null;
 
   constructor(
@@ -14,6 +15,7 @@ export class AdminUserListItemView {
     roles: UserRole[],
     isActive: boolean,
     ofss: { id: string; name: string }[],
+    distributor: { id: string; name: string } | null,
     lastLoginAt: Date | null,
   ) {
     this.id = id;
@@ -21,6 +23,7 @@ export class AdminUserListItemView {
     this.roles = roles;
     this.isActive = isActive;
     this.ofss = ofss;
+    this.distributor = distributor;
     this.lastLoginAt = lastLoginAt;
   }
 }

--- a/apps/backend/src/domain/eligibility-simulation/eligibility-simulation.repository.interface.ts
+++ b/apps/backend/src/domain/eligibility-simulation/eligibility-simulation.repository.interface.ts
@@ -68,12 +68,25 @@ export type PortalEligibilitySimulationContactResult = {
   resources: number | null;
   action: string | null;
   status: string | null;
+  transmittedDistributors?: { id: string; name: string }[];
+  ofsId?: string;
+  ofsName?: string;
+  ofsEmail?: string | null;
+  ofsPhone?: string | null;
+  ofsWebsiteUrl?: string | null;
 };
 
 export type PortalEligibilitySimulationContactFilters = {
   ofsId: string;
   departementIds: string[];
   regionIds: string[];
+  startDate?: string;
+  endDate?: string;
+};
+
+export type DistributorPortalContactFilters = {
+  distributorId: string;
+  ofsId?: string;
   startDate?: string;
   endDate?: string;
 };
@@ -102,5 +115,16 @@ export interface EligibilitySimulationRepositoryInterface {
   hasPortalContactInOfsScope(
     simulationId: string,
     filters: PortalEligibilitySimulationContactFilters,
+  ): Promise<boolean>;
+  findPortalContactsByDistributorScope(
+    pagination: PaginationProps,
+    filters: DistributorPortalContactFilters,
+  ): Promise<[PortalEligibilitySimulationContactResult[], total: number]>;
+  findAllPortalContactsByDistributorScope(
+    filters: DistributorPortalContactFilters,
+  ): Promise<PortalEligibilitySimulationContactResult[]>;
+  hasPortalContactInDistributorScope(
+    simulationId: string,
+    filters: DistributorPortalContactFilters,
   ): Promise<boolean>;
 }

--- a/apps/backend/src/domain/user/user-role.enum.ts
+++ b/apps/backend/src/domain/user/user-role.enum.ts
@@ -1,4 +1,5 @@
 export enum UserRole {
   ADMIN = 'admin',
   OFS = 'ofs',
+  DISTRIBUTOR = 'commercialisateur',
 }

--- a/apps/backend/src/domain/user/user.interface.ts
+++ b/apps/backend/src/domain/user/user.interface.ts
@@ -1,4 +1,5 @@
 import { OfsEntity } from 'src/infrastructure/ofs/ofs.entity';
+import { DistributorEntity } from 'src/infrastructure/distributor/distributor.entity';
 import { UserRole } from './user-role.enum';
 
 export interface UserInterface {
@@ -8,6 +9,7 @@ export interface UserInterface {
   roles: UserRole[];
   isActive: boolean;
   ofss: OfsEntity[];
+  distributor: DistributorEntity | null;
   lastLoginAt?: Date | null;
   createdAt: Date;
   updatedAt: Date;

--- a/apps/backend/src/infrastructure/auth/controllers/portal-auth.controller.ts
+++ b/apps/backend/src/infrastructure/auth/controllers/portal-auth.controller.ts
@@ -62,7 +62,7 @@ export class PortalAuthController {
 
       if (
         !user.roles.some((role) =>
-          [UserRole.ADMIN, UserRole.OFS].includes(role),
+          [UserRole.ADMIN, UserRole.OFS, UserRole.DISTRIBUTOR].includes(role),
         )
       ) {
         throw new UnauthorizedException();
@@ -113,11 +113,19 @@ export class PortalAuthController {
       throw new UnauthorizedException();
     }
 
+    if (user.roles.includes(UserRole.DISTRIBUTOR) && !user.distributor) {
+      await this.userSessionService.destroyAllForUserId(user.id);
+      throw new UnauthorizedException();
+    }
+
     return {
       id: user.id,
       email: user.email,
       roles: user.roles,
       canAccessAllOfss: user.roles.includes(UserRole.ADMIN),
+      distributor: user.distributor
+        ? { id: user.distributor.id, name: user.distributor.name }
+        : null,
       ofss: user.roles.includes(UserRole.ADMIN)
         ? []
         : user.ofss

--- a/apps/backend/src/infrastructure/auth/guards/portal-api-authenticated.guard.ts
+++ b/apps/backend/src/infrastructure/auth/guards/portal-api-authenticated.guard.ts
@@ -15,7 +15,7 @@ export class PortalApiAuthenticatedGuard implements CanActivate {
       !request.isAuthenticated() ||
       request.user?.isActive !== true ||
       !request.user?.roles?.some((role: UserRole) =>
-        [UserRole.ADMIN, UserRole.OFS].includes(role),
+        [UserRole.ADMIN, UserRole.OFS, UserRole.DISTRIBUTOR].includes(role),
       )
     ) {
       throw new UnauthorizedException();

--- a/apps/backend/src/infrastructure/eligibility-simulation/eligibility-simulation.repository.ts
+++ b/apps/backend/src/infrastructure/eligibility-simulation/eligibility-simulation.repository.ts
@@ -12,6 +12,7 @@ import {
   GroupSimulationsByYearAndMonthResult,
   PortalEligibilitySimulationContactFilters,
   PortalEligibilitySimulationContactResult,
+  DistributorPortalContactFilters,
 } from 'src/domain/eligibility-simulation/eligibility-simulation.repository.interface';
 import { EligibilitySimulationEntity } from './eligibility-simulation.entity';
 import { PaginationProps } from 'src/domain/common/paginationProps';
@@ -325,6 +326,58 @@ export class EligibilitySimulationRepository
     return total > 0;
   }
 
+  public async findPortalContactsByDistributorScope(
+    pagination: PaginationProps,
+    filters: DistributorPortalContactFilters,
+  ): Promise<[PortalEligibilitySimulationContactResult[], number]> {
+    const query = this.createDistributorPortalContactsQuery(filters);
+
+    query.orderBy(
+      'COALESCE(eligibility_simulation."landbotDate", eligibility_simulation."createdAt")',
+      'DESC',
+    );
+    query.addOrderBy('location.id', 'DESC');
+    query.offset((pagination.page - 1) * pagination.pageSize);
+    query.limit(pagination.pageSize);
+
+    const items =
+      await query.getRawMany<PortalEligibilitySimulationContactResult>();
+    const total = await this.createDistributorPortalContactsQuery(
+      filters,
+      false,
+    ).getCount();
+
+    return [items, total];
+  }
+
+  public async findAllPortalContactsByDistributorScope(
+    filters: DistributorPortalContactFilters,
+  ): Promise<PortalEligibilitySimulationContactResult[]> {
+    const query = this.createDistributorPortalContactsQuery(filters);
+
+    query.orderBy(
+      'COALESCE(eligibility_simulation."landbotDate", eligibility_simulation."createdAt")',
+      'DESC',
+    );
+    query.addOrderBy('location.id', 'DESC');
+
+    return query.getRawMany<PortalEligibilitySimulationContactResult>();
+  }
+
+  public async hasPortalContactInDistributorScope(
+    simulationId: string,
+    filters: DistributorPortalContactFilters,
+  ): Promise<boolean> {
+    const total = await this.createDistributorPortalContactsQuery(
+      filters,
+      false,
+    )
+      .andWhere('eligibility_simulation.id = :simulationId', { simulationId })
+      .getCount();
+
+    return total > 0;
+  }
+
   private createPortalContactsQuery(
     filters: PortalEligibilitySimulationContactFilters,
     withSelects = true,
@@ -371,13 +424,20 @@ export class EligibilitySimulationRepository
         )
         .addSelect('eligibility_simulation."housingType"', 'housingType')
         .addSelect('eligibility_simulation.resources', 'resources')
+        .addSelect('ofs_eligibility_simulation.action', 'action')
+        .addSelect('ofs_eligibility_simulation.status', 'status')
         .addSelect(
-          'ofs_eligibility_simulation.action',
-          'action',
-        )
-        .addSelect(
-          'ofs_eligibility_simulation.status',
-          'status',
+          `(SELECT COALESCE(json_agg(json_build_object('id', distributor.id, 'name', distributor.name) ORDER BY distributor.name), '[]'::json)
+            FROM commercial_transmission transmission
+            INNER JOIN distributor distributor ON distributor.id = transmission."distributorId"
+            WHERE transmission."ofsId" = :ofsId
+            AND transmission."isActive" = true
+            AND (
+              transmission."scopeType" = 'ALL'
+              OR location.citycode = ANY(transmission."inseeCodes")
+              OR departement.code = ANY(transmission."departementCodes")
+            ))`,
+          'transmittedDistributors',
         );
     }
 
@@ -425,5 +485,105 @@ export class EligibilitySimulationRepository
     }
 
     return false;
+  }
+
+  private createDistributorPortalContactsQuery(
+    filters: DistributorPortalContactFilters,
+    withSelects = true,
+  ) {
+    const query = this.repository
+      .createQueryBuilder('eligibility_simulation')
+      .innerJoin('eligibility_simulation.locations', 'location')
+      .innerJoin('location.departement', 'departement')
+      .innerJoin('departement.region', 'region')
+      .innerJoin(
+        'commercial_transmission',
+        'commercial_transmission',
+        `commercial_transmission."distributorId" = :distributorId
+        AND commercial_transmission."isActive" = true
+        AND (
+          commercial_transmission."scopeType" = 'ALL'
+          OR location.citycode = ANY(commercial_transmission."inseeCodes")
+          OR departement.code = ANY(commercial_transmission."departementCodes")
+        )`,
+        { distributorId: filters.distributorId },
+      )
+      .innerJoin('ofs', 'ofs', 'ofs.id = commercial_transmission."ofsId"')
+      .leftJoin(
+        'distributor_eligibility_simulation',
+        'distributor_eligibility_simulation',
+        'distributor_eligibility_simulation."eligibilitySimulationId" = eligibility_simulation.id AND distributor_eligibility_simulation."distributorId" = :distributorId',
+        { distributorId: filters.distributorId },
+      )
+      .where('eligibility_simulation."hasRefusedConnection" = false')
+      .andWhere('eligibility_simulation.email IS NOT NULL')
+      .andWhere('eligibility_simulation.contribution IS NOT NULL')
+      .andWhere('eligibility_simulation.resources IS NOT NULL')
+      .andWhere(
+        `(EXISTS (
+          SELECT 1 FROM ofs_departement
+          WHERE ofs_departement."ofsId" = ofs.id
+          AND ofs_departement."departementId" = departement.id
+        ) OR EXISTS (
+          SELECT 1 FROM ofs_region
+          WHERE ofs_region."ofsId" = ofs.id
+          AND ofs_region."regionId" = region.id
+        ))`,
+      );
+
+    if (filters.ofsId) {
+      query.andWhere('ofs.id = :ofsId', { ofsId: filters.ofsId });
+    }
+
+    if (filters.startDate) {
+      query.andWhere(
+        'DATE(COALESCE(eligibility_simulation."landbotDate", eligibility_simulation."createdAt")) >= :startDate',
+        { startDate: filters.startDate },
+      );
+    }
+
+    if (filters.endDate) {
+      query.andWhere(
+        'DATE(COALESCE(eligibility_simulation."landbotDate", eligibility_simulation."createdAt")) <= :endDate',
+        { endDate: filters.endDate },
+      );
+    }
+
+    if (withSelects) {
+      query
+        .select('eligibility_simulation.id', 'simulationId')
+        .addSelect('location.id', 'locationId')
+        .addSelect(
+          'COALESCE(eligibility_simulation."landbotDate", eligibility_simulation."createdAt")',
+          'submittedAt',
+        )
+        .addSelect(
+          `NULLIF(TRIM(CONCAT(COALESCE(eligibility_simulation."firstName", ''), ' ', COALESCE(eligibility_simulation."lastName", ''))), '')`,
+          'fullName',
+        )
+        .addSelect('eligibility_simulation.email', 'email')
+        .addSelect('eligibility_simulation.phone', 'phone')
+        .addSelect('departement.code', 'departementCode')
+        .addSelect('location.city', 'city')
+        .addSelect('eligibility_simulation.contribution', 'contribution')
+        .addSelect('eligibility_simulation."householdSize"', 'householdSize')
+        .addSelect('eligibility_simulation."hasDisability"', 'hasDisability')
+        .addSelect('eligibility_simulation."taxableIncome"', 'taxableIncome')
+        .addSelect(
+          'eligibility_simulation."propertySituation"',
+          'propertySituation',
+        )
+        .addSelect('eligibility_simulation."housingType"', 'housingType')
+        .addSelect('eligibility_simulation.resources', 'resources')
+        .addSelect('distributor_eligibility_simulation.action', 'action')
+        .addSelect('distributor_eligibility_simulation.status', 'status')
+        .addSelect('ofs.id', 'ofsId')
+        .addSelect('ofs.name', 'ofsName')
+        .addSelect('ofs.email', 'ofsEmail')
+        .addSelect('ofs.phone', 'ofsPhone')
+        .addSelect('ofs."websiteUrl"', 'ofsWebsiteUrl');
+    }
+
+    return query;
   }
 }

--- a/apps/backend/src/infrastructure/ofs/commercial-transmission.entity.ts
+++ b/apps/backend/src/infrastructure/ofs/commercial-transmission.entity.ts
@@ -1,0 +1,64 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Unique,
+  UpdateDateColumn,
+} from 'typeorm';
+import { DistributorEntity } from '../distributor/distributor.entity';
+import { OfsEntity } from './ofs.entity';
+
+export enum CommercialTransmissionScopeType {
+  ALL = 'ALL',
+  GEOGRAPHIC = 'GEOGRAPHIC',
+}
+
+@Entity('commercial_transmission')
+@Unique('UQ_commercial_transmission_ofs_distributor', [
+  'ofsId',
+  'distributorId',
+])
+export class CommercialTransmissionEntity {
+  @PrimaryGeneratedColumn('uuid')
+  public id: string;
+
+  @Column({ type: 'uuid' })
+  public ofsId: string;
+
+  @Column({ type: 'uuid' })
+  public distributorId: string;
+
+  @ManyToOne(() => OfsEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'ofsId' })
+  public ofs: OfsEntity;
+
+  @ManyToOne(() => DistributorEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'distributorId' })
+  public distributor: DistributorEntity;
+
+  @Column({ type: 'boolean', nullable: false, default: true })
+  public isActive: boolean;
+
+  @Column({
+    type: 'enum',
+    enum: CommercialTransmissionScopeType,
+    nullable: false,
+    default: CommercialTransmissionScopeType.ALL,
+  })
+  public scopeType: CommercialTransmissionScopeType;
+
+  @Column({ type: 'varchar', array: true, nullable: false, default: [] })
+  public inseeCodes: string[];
+
+  @Column({ type: 'varchar', array: true, nullable: false, default: [] })
+  public departementCodes: string[];
+
+  @CreateDateColumn()
+  public createdAt: Date;
+
+  @UpdateDateColumn()
+  public updatedAt: Date;
+}

--- a/apps/backend/src/infrastructure/ofs/controllers/api/portal-ofss.controller.ts
+++ b/apps/backend/src/infrastructure/ofs/controllers/api/portal-ofss.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   NotFoundException,
   Param,
+  Post,
   Put,
   Query,
   Res,
@@ -24,10 +25,14 @@ import { ExportPortalContactLinesUsecase } from 'src/application/eligibility-sim
 import { PortalUpdateOfsDto } from '../../dtos/portal-update.dto';
 import { OfsEntity } from '../../ofs.entity';
 import { EligibilitySimulationRepository } from 'src/infrastructure/eligibility-simulation/eligibility-simulation.repository';
-import {
-  OfsEligibilitySimulationEntity,
-} from '../../ofs-eligibility-simulation.entity';
+import { OfsEligibilitySimulationEntity } from '../../ofs-eligibility-simulation.entity';
 import { UpdatePortalSimulationMetadataDto } from '../../dtos/update-portal-simulation-metadata.dto';
+import {
+  CommercialTransmissionEntity,
+  CommercialTransmissionScopeType,
+} from '../../commercial-transmission.entity';
+import { DistributorEntity } from 'src/infrastructure/distributor/distributor.entity';
+import { DistributorEligibilitySimulationEntity } from '../../distributor-eligibility-simulation.entity';
 
 @ApiExcludeController()
 @Controller('/api/portal/ofss')
@@ -37,6 +42,12 @@ export class PortalOfssController {
     private readonly ofsRepository: Repository<OfsEntity>,
     @InjectRepository(OfsEligibilitySimulationEntity)
     private readonly ofsEligibilitySimulationRepository: Repository<OfsEligibilitySimulationEntity>,
+    @InjectRepository(CommercialTransmissionEntity)
+    private readonly commercialTransmissionRepository: Repository<CommercialTransmissionEntity>,
+    @InjectRepository(DistributorEntity)
+    private readonly distributorRepository: Repository<DistributorEntity>,
+    @InjectRepository(DistributorEligibilitySimulationEntity)
+    private readonly distributorEligibilitySimulationRepository: Repository<DistributorEligibilitySimulationEntity>,
     private readonly findPortalContactLinesUsecase: FindPortalContactLinesUsecase,
     private readonly exportPortalContactLinesUsecase: ExportPortalContactLinesUsecase,
     private readonly eligibilitySimulationRepository: EligibilitySimulationRepository,
@@ -64,6 +75,224 @@ export class PortalOfssController {
       departements:
         ofs.departements?.map((departement) => departement.name) || [],
     }));
+  }
+
+  @UseGuards(PortalApiAuthenticatedGuard)
+  @Get(':id/commercial-transmissions')
+  public async commercialTransmissions(
+    @Param('id') id: string,
+    @Req() req: Request,
+  ) {
+    const ofs = await this.findAccessibleOfs(id, req.user as UserEntity);
+    const transmissions = await this.commercialTransmissionRepository.find({
+      where: { ofsId: ofs.id },
+      relations: ['distributor'],
+      order: { updatedAt: 'DESC' },
+    });
+
+    return transmissions.map((transmission) =>
+      this.serializeTransmission(transmission),
+    );
+  }
+
+  @UseGuards(PortalApiAuthenticatedGuard)
+  @Post(':id/commercial-transmissions')
+  public async createCommercialTransmission(
+    @Param('id') id: string,
+    @Body()
+    body: {
+      distributorId?: string;
+      scopeType?: CommercialTransmissionScopeType;
+      inseeCodes?: string[];
+      departementCodes?: string[];
+      isActive?: boolean;
+    },
+    @Req() req: Request,
+  ) {
+    const ofs = await this.findAccessibleOfs(id, req.user as UserEntity);
+    const distributor = body.distributorId
+      ? await this.distributorRepository.findOneBy({ id: body.distributorId })
+      : null;
+
+    if (!distributor) {
+      throw new BadRequestException('Commercialisateur invalide.');
+    }
+
+    if (!ofs.distributors.some((item) => item.id === distributor.id)) {
+      throw new BadRequestException(
+        "Ce commercialisateur n'est pas rattaché à cet OFS.",
+      );
+    }
+
+    const existing = await this.commercialTransmissionRepository.findOne({
+      where: { ofsId: ofs.id, distributorId: distributor.id },
+    });
+
+    if (existing) {
+      throw new BadRequestException('Cette transmission existe déjà.');
+    }
+
+    const transmission = this.commercialTransmissionRepository.create({
+      ofsId: ofs.id,
+      distributorId: distributor.id,
+      distributor,
+      isActive: body.isActive ?? true,
+      ...this.resolveTransmissionScope(body),
+    });
+
+    return this.serializeTransmission(
+      await this.commercialTransmissionRepository.save(transmission),
+    );
+  }
+
+  @UseGuards(PortalApiAuthenticatedGuard)
+  @Put(':id/commercial-transmissions/:transmissionId')
+  public async updateCommercialTransmission(
+    @Param('id') id: string,
+    @Param('transmissionId') transmissionId: string,
+    @Body()
+    body: {
+      scopeType?: CommercialTransmissionScopeType;
+      inseeCodes?: string[];
+      departementCodes?: string[];
+      isActive?: boolean;
+    },
+    @Req() req: Request,
+  ) {
+    const ofs = await this.findAccessibleOfs(id, req.user as UserEntity);
+    const transmission = await this.commercialTransmissionRepository.findOne({
+      where: { id: transmissionId, ofsId: ofs.id },
+      relations: ['distributor'],
+    });
+
+    if (!transmission) {
+      throw new NotFoundException();
+    }
+
+    Object.assign(transmission, this.resolveTransmissionScope(body));
+
+    if (typeof body.isActive === 'boolean') {
+      transmission.isActive = body.isActive;
+    }
+
+    return this.serializeTransmission(
+      await this.commercialTransmissionRepository.save(transmission),
+    );
+  }
+
+  @UseGuards(PortalApiAuthenticatedGuard)
+  @Get('/commercialisateur/ofss')
+  public async distributorOfss(@Req() req: Request) {
+    const user = req.user as UserEntity;
+    const distributorId = this.requireDistributor(user).id;
+    const transmissions = await this.commercialTransmissionRepository.find({
+      where: { distributorId, isActive: true },
+      relations: ['ofs'],
+      order: { updatedAt: 'DESC' },
+    });
+
+    return transmissions.map((transmission) => ({
+      transmissionId: transmission.id,
+      ofs: {
+        id: transmission.ofs.id,
+        name: transmission.ofs.name,
+        email: transmission.ofs.email,
+        phone: transmission.ofs.phone,
+        websiteUrl: transmission.ofs.websiteUrl,
+      },
+      scopeType: transmission.scopeType,
+      inseeCodes: transmission.inseeCodes,
+      departementCodes: transmission.departementCodes,
+    }));
+  }
+
+  @UseGuards(PortalApiAuthenticatedGuard)
+  @Get('/commercialisateur/eligibility-simulations')
+  public async distributorEligibilitySimulations(
+    @Query() pagination: PaginationDTO,
+    @Query('ofsId') ofsId: string | undefined,
+    @Req() req: Request,
+  ) {
+    const distributorId = this.requireDistributor(req.user as UserEntity).id;
+
+    return this.findDistributorPortalContactLines(
+      {
+        page: pagination.page || 1,
+        pageSize: pagination.pageSize || 20,
+      },
+      { distributorId, ofsId },
+    );
+  }
+
+  @UseGuards(PortalApiAuthenticatedGuard)
+  @Get('/commercialisateur/eligibility-simulations/export')
+  public async exportDistributorEligibilitySimulations(
+    @Query('startDate') startDate: string | undefined,
+    @Query('endDate') endDate: string | undefined,
+    @Query('ofsId') ofsId: string | undefined,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    const distributorId = this.requireDistributor(req.user as UserEntity).id;
+    const validatedDates = this.validateExportDates(startDate, endDate);
+    const lines =
+      await this.eligibilitySimulationRepository.findAllPortalContactsByDistributorScope(
+        { distributorId, ofsId, ...validatedDates },
+      );
+    const csv = this.buildCsv(
+      lines.map((line) => this.toPortalContactLineForCsv(line)),
+    );
+
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="transmissions-commerciales-${validatedDates.startDate}-${validatedDates.endDate}.csv"`,
+    );
+
+    return res.send(Buffer.from(csv, 'utf-8'));
+  }
+
+  @UseGuards(PortalApiAuthenticatedGuard)
+  @Put('/commercialisateur/eligibility-simulations/:simulationId/metadata')
+  public async updateDistributorEligibilitySimulationMetadata(
+    @Param('simulationId') simulationId: string,
+    @Body() body: UpdatePortalSimulationMetadataDto,
+    @Req() req: Request,
+  ) {
+    const distributorId = this.requireDistributor(req.user as UserEntity).id;
+    const isAccessible =
+      await this.eligibilitySimulationRepository.hasPortalContactInDistributorScope(
+        simulationId,
+        { distributorId },
+      );
+
+    if (!isAccessible) {
+      throw new NotFoundException();
+    }
+
+    let metadata =
+      await this.distributorEligibilitySimulationRepository.findOne({
+        where: { distributorId, eligibilitySimulationId: simulationId },
+      });
+
+    if (!metadata) {
+      metadata = this.distributorEligibilitySimulationRepository.create({
+        distributorId,
+        eligibilitySimulationId: simulationId,
+      });
+    }
+
+    metadata.action = body.action ?? null;
+    metadata.status = body.status ?? null;
+
+    const saved =
+      await this.distributorEligibilitySimulationRepository.save(metadata);
+
+    return {
+      simulationId: saved.eligibilitySimulationId,
+      action: saved.action,
+      status: saved.status,
+    };
   }
 
   @UseGuards(PortalApiAuthenticatedGuard)
@@ -265,6 +494,107 @@ export class PortalOfssController {
     return ofs;
   }
 
+  private requireDistributor(user: UserEntity): DistributorEntity {
+    if (!user.roles.includes(UserRole.DISTRIBUTOR) || !user.distributor) {
+      throw new NotFoundException();
+    }
+
+    return user.distributor;
+  }
+
+  private async findDistributorPortalContactLines(
+    pagination: { page: number; pageSize: number },
+    filters: { distributorId: string; ofsId?: string },
+  ) {
+    const [items, total] =
+      await this.eligibilitySimulationRepository.findPortalContactsByDistributorScope(
+        pagination,
+        filters,
+      );
+
+    return {
+      items: items.map((line) => this.toPortalContactLineForCsv(line)),
+      totalCount: total,
+      page: pagination.page,
+      pageSize: pagination.pageSize,
+      pagesCount: Math.ceil(total / pagination.pageSize),
+      hasPreviousPage: pagination.page > 1,
+      hasNextPage: pagination.page * pagination.pageSize < total,
+    };
+  }
+
+  private toPortalContactLineForCsv(line: any) {
+    return {
+      ...line,
+      submittedAt: new Date(line.submittedAt),
+      transmittedDistributors: line.transmittedDistributors || [],
+      ofs: line.ofsId
+        ? {
+            id: line.ofsId,
+            name: line.ofsName,
+            email: line.ofsEmail || null,
+            phone: line.ofsPhone || null,
+            websiteUrl: line.ofsWebsiteUrl || null,
+          }
+        : null,
+    };
+  }
+
+  private resolveTransmissionScope(body: {
+    scopeType?: CommercialTransmissionScopeType;
+    inseeCodes?: string[];
+    departementCodes?: string[];
+  }) {
+    const scopeType =
+      body.scopeType === CommercialTransmissionScopeType.GEOGRAPHIC
+        ? CommercialTransmissionScopeType.GEOGRAPHIC
+        : CommercialTransmissionScopeType.ALL;
+    const inseeCodes = this.normalizeCodes(body.inseeCodes);
+    const departementCodes = this.normalizeCodes(body.departementCodes);
+
+    if (
+      scopeType === CommercialTransmissionScopeType.GEOGRAPHIC &&
+      inseeCodes.length === 0 &&
+      departementCodes.length === 0
+    ) {
+      throw new BadRequestException('Le périmètre géographique est vide.');
+    }
+
+    return {
+      scopeType,
+      inseeCodes:
+        scopeType === CommercialTransmissionScopeType.GEOGRAPHIC
+          ? inseeCodes
+          : [],
+      departementCodes:
+        scopeType === CommercialTransmissionScopeType.GEOGRAPHIC
+          ? departementCodes
+          : [],
+    };
+  }
+
+  private normalizeCodes(values?: string[]) {
+    return Array.from(
+      new Set((values || []).map((value) => value.trim()).filter(Boolean)),
+    );
+  }
+
+  private serializeTransmission(transmission: CommercialTransmissionEntity) {
+    return {
+      id: transmission.id,
+      ofsId: transmission.ofsId,
+      distributor: {
+        id: transmission.distributor.id,
+        name: transmission.distributor.name,
+      },
+      isActive: transmission.isActive,
+      scopeType: transmission.scopeType,
+      inseeCodes: transmission.inseeCodes,
+      departementCodes: transmission.departementCodes,
+      updatedAt: transmission.updatedAt,
+    };
+  }
+
   private validateExportDates(startDate?: string, endDate?: string) {
     if (!startDate || !endDate) {
       throw new BadRequestException(
@@ -297,7 +627,9 @@ export class PortalOfssController {
     return { startDate, endDate };
   }
 
-  private buildCsv(lines: Awaited<ReturnType<ExportPortalContactLinesUsecase['execute']>>) {
+  private buildCsv(
+    lines: Awaited<ReturnType<ExportPortalContactLinesUsecase['execute']>>,
+  ) {
     const rows = [
       [
         'date',

--- a/apps/backend/src/infrastructure/ofs/distributor-eligibility-simulation.entity.ts
+++ b/apps/backend/src/infrastructure/ofs/distributor-eligibility-simulation.entity.ts
@@ -1,0 +1,60 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Unique,
+  UpdateDateColumn,
+} from 'typeorm';
+import {
+  OfsEligibilitySimulationAction,
+  OfsEligibilitySimulationStatus,
+} from './ofs-eligibility-simulation.entity';
+import { DistributorEntity } from '../distributor/distributor.entity';
+import { EligibilitySimulationEntity } from '../eligibility-simulation/eligibility-simulation.entity';
+
+@Entity('distributor_eligibility_simulation')
+@Unique('UQ_distributor_eligibility_simulation_distributor_simulation', [
+  'distributorId',
+  'eligibilitySimulationId',
+])
+export class DistributorEligibilitySimulationEntity {
+  @PrimaryGeneratedColumn('uuid')
+  public id: string;
+
+  @Column({ type: 'uuid' })
+  public distributorId: string;
+
+  @Column({ type: 'uuid' })
+  public eligibilitySimulationId: string;
+
+  @ManyToOne(() => DistributorEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'distributorId' })
+  public distributor: DistributorEntity;
+
+  @ManyToOne(() => EligibilitySimulationEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'eligibilitySimulationId' })
+  public eligibilitySimulation: EligibilitySimulationEntity;
+
+  @Column({
+    type: 'enum',
+    enum: OfsEligibilitySimulationAction,
+    nullable: true,
+  })
+  public action: OfsEligibilitySimulationAction | null;
+
+  @Column({
+    type: 'enum',
+    enum: OfsEligibilitySimulationStatus,
+    nullable: true,
+  })
+  public status: OfsEligibilitySimulationStatus | null;
+
+  @CreateDateColumn()
+  public createdAt: Date;
+
+  @UpdateDateColumn()
+  public updatedAt: Date;
+}

--- a/apps/backend/src/infrastructure/ofs/ofs.module.ts
+++ b/apps/backend/src/infrastructure/ofs/ofs.module.ts
@@ -20,6 +20,9 @@ import { PortalOfssController } from './controllers/api/portal-ofss.controller';
 import { PortalApiAuthenticatedGuard } from '../auth/guards/portal-api-authenticated.guard';
 import { EligibilitySimulationModule } from '../eligibility-simulation/eligibility-simulation.module';
 import { OfsEligibilitySimulationEntity } from './ofs-eligibility-simulation.entity';
+import { CommercialTransmissionEntity } from './commercial-transmission.entity';
+import { DistributorEligibilitySimulationEntity } from './distributor-eligibility-simulation.entity';
+import { DistributorEntity } from '../distributor/distributor.entity';
 import { FindMyOfsApiController } from './controllers/api/find-my-ofs.controller';
 import { FindMyOfsUsecase } from 'src/application/ofs/usecases/findMyOfs.usecase';
 import { BrsDiffusionWebsiteModule } from '../brs-diffusion-website/brs-diffusion-website.module';
@@ -27,7 +30,13 @@ import { GeocoderModule } from '../geocoder/geocoder.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([OfsEntity, OfsEligibilitySimulationEntity]),
+    TypeOrmModule.forFeature([
+      OfsEntity,
+      OfsEligibilitySimulationEntity,
+      CommercialTransmissionEntity,
+      DistributorEligibilitySimulationEntity,
+      DistributorEntity,
+    ]),
     RegionModule,
     DepartementModule,
     DistributorModule,

--- a/apps/backend/src/infrastructure/persistence/migrations/1776000000000-add_commercialisateur_transmissions.ts
+++ b/apps/backend/src/infrastructure/persistence/migrations/1776000000000-add_commercialisateur_transmissions.ts
@@ -1,0 +1,86 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCommercialisateurTransmissions1776000000000
+  implements MigrationInterface
+{
+  name = 'AddCommercialisateurTransmissions1776000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "public"."user_roles_enum" ADD VALUE IF NOT EXISTS 'commercialisateur'`,
+    );
+    await queryRunner.query(`ALTER TABLE "user" ADD "distributorId" uuid`);
+    await queryRunner.query(
+      `CREATE TYPE "public"."commercial_transmission_scopetype_enum" AS ENUM('ALL', 'GEOGRAPHIC')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "commercial_transmission" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "ofsId" uuid NOT NULL, "distributorId" uuid NOT NULL, "isActive" boolean NOT NULL DEFAULT true, "scopeType" "public"."commercial_transmission_scopetype_enum" NOT NULL DEFAULT 'ALL', "inseeCodes" character varying array NOT NULL DEFAULT '{}', "departementCodes" character varying array NOT NULL DEFAULT '{}', "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "UQ_commercial_transmission_ofs_distributor" UNIQUE ("ofsId", "distributorId"), CONSTRAINT "PK_commercial_transmission" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_commercial_transmission_distributor_active" ON "commercial_transmission" ("distributorId", "isActive")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_commercial_transmission_ofs" ON "commercial_transmission" ("ofsId")`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "distributor_eligibility_simulation" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "distributorId" uuid NOT NULL, "eligibilitySimulationId" uuid NOT NULL, "action" "public"."ofs_eligibility_simulation_action_enum", "status" "public"."ofs_eligibility_simulation_status_enum", "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "UQ_distributor_eligibility_simulation_distributor_simulation" UNIQUE ("distributorId", "eligibilitySimulationId"), CONSTRAINT "PK_distributor_eligibility_simulation" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_distributor_eligibility_simulation_distributor" ON "distributor_eligibility_simulation" ("distributorId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_distributor_eligibility_simulation_simulation" ON "distributor_eligibility_simulation" ("eligibilitySimulationId")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD CONSTRAINT "FK_user_distributor" FOREIGN KEY ("distributorId") REFERENCES "distributor"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "commercial_transmission" ADD CONSTRAINT "FK_commercial_transmission_ofs" FOREIGN KEY ("ofsId") REFERENCES "ofs"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "commercial_transmission" ADD CONSTRAINT "FK_commercial_transmission_distributor" FOREIGN KEY ("distributorId") REFERENCES "distributor"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "distributor_eligibility_simulation" ADD CONSTRAINT "FK_distributor_eligibility_simulation_distributor" FOREIGN KEY ("distributorId") REFERENCES "distributor"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "distributor_eligibility_simulation" ADD CONSTRAINT "FK_distributor_eligibility_simulation_simulation" FOREIGN KEY ("eligibilitySimulationId") REFERENCES "eligibility_simulation"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "distributor_eligibility_simulation" DROP CONSTRAINT "FK_distributor_eligibility_simulation_simulation"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "distributor_eligibility_simulation" DROP CONSTRAINT "FK_distributor_eligibility_simulation_distributor"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "commercial_transmission" DROP CONSTRAINT "FK_commercial_transmission_distributor"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "commercial_transmission" DROP CONSTRAINT "FK_commercial_transmission_ofs"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" DROP CONSTRAINT "FK_user_distributor"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_distributor_eligibility_simulation_simulation"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_distributor_eligibility_simulation_distributor"`,
+    );
+    await queryRunner.query(`DROP TABLE "distributor_eligibility_simulation"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_commercial_transmission_ofs"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_commercial_transmission_distributor_active"`,
+    );
+    await queryRunner.query(`DROP TABLE "commercial_transmission"`);
+    await queryRunner.query(
+      `DROP TYPE "public"."commercial_transmission_scopetype_enum"`,
+    );
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "distributorId"`);
+  }
+}

--- a/apps/backend/src/infrastructure/persistence/typeorm.config.ts
+++ b/apps/backend/src/infrastructure/persistence/typeorm.config.ts
@@ -14,6 +14,8 @@ import { LocationEntity } from '../location/location.entity';
 import { EligibilitySimulationEntity } from '../eligibility-simulation/eligibility-simulation.entity';
 import { UserPasswordResetTokenEntity } from '../user/user-password-reset-token.entity';
 import { OfsEligibilitySimulationEntity } from '../ofs/ofs-eligibility-simulation.entity';
+import { CommercialTransmissionEntity } from '../ofs/commercial-transmission.entity';
+import { DistributorEligibilitySimulationEntity } from '../ofs/distributor-eligibility-simulation.entity';
 dotenv.config();
 
 const test = process.env.NODE_ENV === 'test';
@@ -41,6 +43,8 @@ export const typeormConfig: DataSourceOptions = {
     EligibilitySimulationEntity,
     UserPasswordResetTokenEntity,
     OfsEligibilitySimulationEntity,
+    CommercialTransmissionEntity,
+    DistributorEligibilitySimulationEntity,
   ],
   migrations: ['dist/infrastructure/persistence/migrations/**/*{.ts,.js}'],
   synchronize: false,

--- a/apps/backend/src/infrastructure/user/controllers/admin/create-user.controller.ts
+++ b/apps/backend/src/infrastructure/user/controllers/admin/create-user.controller.ts
@@ -21,6 +21,7 @@ import { RequestWithFlash } from 'src/types/request-with-flash';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { OfsEntity } from 'src/infrastructure/ofs/ofs.entity';
+import { DistributorEntity } from 'src/infrastructure/distributor/distributor.entity';
 
 @ApiExcludeController()
 @Controller('/users')
@@ -29,6 +30,8 @@ export class CreateUserAdminController {
     private readonly createManagedUserUsecase: CreateManagedUserUsecase,
     @InjectRepository(OfsEntity)
     private readonly ofsRepository: Repository<OfsEntity>,
+    @InjectRepository(DistributorEntity)
+    private readonly distributorRepository: Repository<DistributorEntity>,
   ) {}
 
   @UseGuards(LocalIsAuthenticatedGuard)
@@ -37,6 +40,9 @@ export class CreateUserAdminController {
   @Render('users/create')
   public async createPage(@Query('returnTo') returnTo?: string) {
     const ofss = await this.ofsRepository.find({ order: { name: 'ASC' } });
+    const distributors = await this.distributorRepository.find({
+      order: { name: 'ASC' },
+    });
 
     return {
       layout: 'layouts/main',
@@ -45,10 +51,11 @@ export class CreateUserAdminController {
         { label: 'Utilisateurs', href: '/users' },
         { label: 'Créer un utilisateur' },
       ],
-      form: { email: '', role: '', ofsIds: [] },
+      form: { email: '', role: '', ofsIds: [], distributorId: '' },
       errors: {},
       returnTo,
       ofss,
+      distributors,
       ...UsersPageBuilder.buildSharedFormView(),
     };
   }
@@ -75,6 +82,9 @@ export class CreateUserAdminController {
       });
     } catch (error) {
       const ofss = await this.ofsRepository.find({ order: { name: 'ASC' } });
+      const distributors = await this.distributorRepository.find({
+        order: { name: 'ASC' },
+      });
 
       return res.status(400).render('users/create', {
         layout: 'layouts/main',
@@ -87,9 +97,11 @@ export class CreateUserAdminController {
           email: body.email,
           role: body.role,
           ofsIds: body.ofsIds || [],
+          distributorId: body.distributorId || '',
         },
         errors: UsersPageBuilder.buildCreateErrors(error),
         ofss,
+        distributors,
         ...UsersPageBuilder.buildSharedFormView(),
       });
     }

--- a/apps/backend/src/infrastructure/user/controllers/admin/update-user.controller.ts
+++ b/apps/backend/src/infrastructure/user/controllers/admin/update-user.controller.ts
@@ -27,6 +27,7 @@ import { UserEntity } from '../../user.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { OfsEntity } from 'src/infrastructure/ofs/ofs.entity';
+import { DistributorEntity } from 'src/infrastructure/distributor/distributor.entity';
 
 @ApiExcludeController()
 @Controller('/users')
@@ -38,6 +39,8 @@ export class UpdateUserAdminController {
     private readonly setUserActiveStatusUsecase: SetUserActiveStatusUsecase,
     @InjectRepository(OfsEntity)
     private readonly ofsRepository: Repository<OfsEntity>,
+    @InjectRepository(DistributorEntity)
+    private readonly distributorRepository: Repository<DistributorEntity>,
   ) {}
 
   @UseGuards(LocalIsAuthenticatedGuard)
@@ -52,6 +55,9 @@ export class UpdateUserAdminController {
     const user = await this.findUserByIdUsecase.execute(params.id);
     const currentUser = req.user as UserEntity;
     const ofss = await this.ofsRepository.find({ order: { name: 'ASC' } });
+    const distributors = await this.distributorRepository.find({
+      order: { name: 'ASC' },
+    });
 
     return res.render('users/update', {
       layout: 'layouts/main',
@@ -65,6 +71,7 @@ export class UpdateUserAdminController {
         email: user.email,
         role: user.roles[0],
         ofsIds: user.ofss.map((ofs) => ofs.id),
+        distributorId: user.distributor?.id || '',
       },
       errors: {},
       returnTo,
@@ -72,6 +79,7 @@ export class UpdateUserAdminController {
         'generatedPassword',
       )[0],
       ofss,
+      distributors,
       ...UsersPageBuilder.buildEditPageView(user, currentUser.id, returnTo),
     });
   }
@@ -95,6 +103,7 @@ export class UpdateUserAdminController {
         email: body.email,
         role: body.role,
         ofsIds: body.ofsIds,
+        distributorId: body.distributorId,
       });
 
       await new Promise<void>((resolve) => {
@@ -107,6 +116,9 @@ export class UpdateUserAdminController {
       const user = await this.findUserByIdUsecase.execute(params.id);
       const currentUser = req.user as UserEntity;
       const ofss = await this.ofsRepository.find({ order: { name: 'ASC' } });
+      const distributors = await this.distributorRepository.find({
+        order: { name: 'ASC' },
+      });
 
       return res.status(400).render('users/update', {
         layout: 'layouts/main',
@@ -120,11 +132,13 @@ export class UpdateUserAdminController {
           email: body.email,
           role: body.role,
           ofsIds: body.ofsIds || [],
+          distributorId: body.distributorId || '',
         },
         errors: UsersPageBuilder.buildUpdateErrors(error),
         returnTo,
         generatedPassword: undefined,
         ofss,
+        distributors,
         ...UsersPageBuilder.buildEditPageView(user, currentUser.id, returnTo),
       });
     }

--- a/apps/backend/src/infrastructure/user/dtos/admin/create-user.dto.ts
+++ b/apps/backend/src/infrastructure/user/dtos/admin/create-user.dto.ts
@@ -28,4 +28,8 @@ export class CreateUserDTO {
   @IsString({ each: true })
   @IsOptional()
   public ofsIds?: string[];
+
+  @IsString()
+  @IsOptional()
+  public distributorId?: string;
 }

--- a/apps/backend/src/infrastructure/user/dtos/admin/update-user.dto.ts
+++ b/apps/backend/src/infrastructure/user/dtos/admin/update-user.dto.ts
@@ -28,4 +28,8 @@ export class UpdateUserDTO {
   @IsString({ each: true })
   @IsOptional()
   public ofsIds?: string[];
+
+  @IsString()
+  @IsOptional()
+  public distributorId?: string;
 }

--- a/apps/backend/src/infrastructure/user/user.entity.ts
+++ b/apps/backend/src/infrastructure/user/user.entity.ts
@@ -5,11 +5,13 @@ import {
   Entity,
   JoinTable,
   ManyToMany,
+  ManyToOne,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
 import { UserRole } from 'src/domain/user/user-role.enum';
 import { OfsEntity } from '../ofs/ofs.entity';
+import { DistributorEntity } from '../distributor/distributor.entity';
 
 @Entity('user')
 export class UserEntity implements UserInterface {
@@ -34,6 +36,9 @@ export class UserEntity implements UserInterface {
   })
   public ofss: OfsEntity[];
 
+  @ManyToOne(() => DistributorEntity, { nullable: true, onDelete: 'SET NULL' })
+  public distributor: DistributorEntity | null;
+
   @Column({ type: 'timestamp', nullable: true })
   public lastLoginAt: Date | null;
 
@@ -49,6 +54,7 @@ export class UserEntity implements UserInterface {
     roles: UserRole[] = [UserRole.ADMIN],
     isActive = true,
     ofss?: OfsEntity[],
+    distributor?: DistributorEntity | null,
   ) {
     this.email = email;
     this.password = password;
@@ -59,6 +65,7 @@ export class UserEntity implements UserInterface {
       this.ofss = ofss;
     }
 
+    this.distributor = distributor || null;
     this.lastLoginAt = null;
   }
 }

--- a/apps/backend/src/infrastructure/user/user.module.ts
+++ b/apps/backend/src/infrastructure/user/user.module.ts
@@ -8,6 +8,7 @@ import { SaveUserUseCase } from 'src/application/user/usecases/save.usecase';
 import { SessionModule } from '../session/session.module';
 import { OfsEntity } from '../ofs/ofs.entity';
 import { UserPasswordResetTokenEntity } from './user-password-reset-token.entity';
+import { DistributorEntity } from '../distributor/distributor.entity';
 import { FindAllUsersUsecase } from 'src/application/user/usecases/findAll.usecase';
 import { FindUserByIdUsecase } from 'src/application/user/usecases/findById.usecase';
 import { CreateManagedUserUsecase } from 'src/application/user/usecases/create-managed-user.usecase';
@@ -26,6 +27,7 @@ import { ResetPasswordWithTokenUsecase } from 'src/application/user/usecases/res
     TypeOrmModule.forFeature([
       UserEntity,
       OfsEntity,
+      DistributorEntity,
       UserPasswordResetTokenEntity,
     ]),
     SessionModule,

--- a/apps/backend/src/infrastructure/user/user.repository.ts
+++ b/apps/backend/src/infrastructure/user/user.repository.ts
@@ -23,14 +23,14 @@ export class UserRepository implements UserRepositoryInterface {
   public async findOneByEmail(email: string): Promise<UserEntity | null> {
     return this.repository.findOne({
       where: { email },
-      relations: ['ofss'],
+      relations: ['ofss', 'distributor'],
     });
   }
 
   public async findById(id: string): Promise<UserEntity | null> {
     return this.repository.findOne({
       where: { id },
-      relations: ['ofss'],
+      relations: ['ofss', 'distributor'],
     });
   }
 
@@ -42,7 +42,8 @@ export class UserRepository implements UserRepositoryInterface {
 
     const query = this.repository
       .createQueryBuilder('user')
-      .leftJoinAndSelect('user.ofss', 'ofss');
+      .leftJoinAndSelect('user.ofss', 'ofss')
+      .leftJoinAndSelect('user.distributor', 'distributor');
 
     if (filters?.role) {
       query.andWhere(':role = ANY(user.roles)', { role: filters.role });

--- a/apps/backend/src/infrastructure/user/users-page.builder.ts
+++ b/apps/backend/src/infrastructure/user/users-page.builder.ts
@@ -7,7 +7,11 @@ import { UsersFiltersView } from './users.types';
 
 export class UsersPageBuilder {
   public static toRole(value?: string): UserRole | undefined {
-    if (value === UserRole.ADMIN || value === UserRole.OFS) {
+    if (
+      value === UserRole.ADMIN ||
+      value === UserRole.OFS ||
+      value === UserRole.DISTRIBUTOR
+    ) {
       return value;
     }
 
@@ -15,7 +19,11 @@ export class UsersPageBuilder {
   }
 
   public static roleLabel(role: UserRole): string {
-    return role === UserRole.ADMIN ? 'Admin' : 'OFS';
+    if (role === UserRole.ADMIN) {
+      return 'Admin';
+    }
+
+    return role === UserRole.DISTRIBUTOR ? 'Commercialisateur' : 'OFS';
   }
 
   public static activeLabel(isActive: boolean): string {
@@ -27,6 +35,7 @@ export class UsersPageBuilder {
       roles: [
         { value: Role.ADMIN, label: 'Admin' },
         { value: Role.OFS, label: 'OFS' },
+        { value: Role.DISTRIBUTOR, label: 'Commercialisateur' },
       ],
       notes: {
         generatedPassword:
@@ -120,6 +129,7 @@ export class UsersPageBuilder {
       email: message,
       role: message,
       ofsIds: message,
+      distributorId: message,
     };
   }
 

--- a/apps/backend/src/views/users/create.hbs
+++ b/apps/backend/src/views/users/create.hbs
@@ -38,6 +38,17 @@
       </select>
     </div>
 
+    <div id="distributor-section" class="{{#if (isEqual form.role 'commercialisateur')}}block{{else}}hidden{{/if}}">
+      <label for="distributorId" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Commercialisateur rattaché</label>
+      <select name="distributorId" id="distributorId"
+        class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white">
+        <option value="">Sélectionner un commercialisateur</option>
+        {{#each distributors as |distributor|}}
+        <option value="{{distributor.id}}" {{#if (isEqual ../form.distributorId distributor.id)}}selected{{/if}}>{{distributor.name}}</option>
+        {{/each}}
+      </select>
+    </div>
+
     <div class="mt-6 flex items-center gap-3">
       <button type="submit" class="text-white inline-flex items-center bg-primary-700 hover:bg-primary-800 focus:ring-4 focus:outline-none focus:ring-primary-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-primary-600 dark:hover:bg-primary-700 dark:focus:ring-primary-800">Créer un utilisateur</button>
       <a href="/users" class="text-sm font-medium text-gray-700 hover:underline dark:text-gray-200">Retour à la liste</a>
@@ -50,15 +61,23 @@
     const roleField = document.getElementById('role');
     const ofsSection = document.getElementById('ofs-section');
     const ofsSelect = document.getElementById('ofsIds');
+    const distributorSection = document.getElementById('distributor-section');
+    const distributorSelect = document.getElementById('distributorId');
 
     const sync = () => {
       const show = roleField?.value === 'ofs';
+      const showDistributor = roleField?.value === 'commercialisateur';
       ofsSection?.classList.toggle('hidden', !show);
       ofsSection?.classList.toggle('block', show);
+      distributorSection?.classList.toggle('hidden', !showDistributor);
+      distributorSection?.classList.toggle('block', showDistributor);
       if (!show && ofsSelect instanceof HTMLSelectElement) {
         Array.from(ofsSelect.options).forEach((option) => {
           option.selected = false;
         });
+      }
+      if (!showDistributor && distributorSelect instanceof HTMLSelectElement) {
+        distributorSelect.value = '';
       }
     };
 

--- a/apps/backend/src/views/users/index.hbs
+++ b/apps/backend/src/views/users/index.hbs
@@ -28,6 +28,7 @@
         <option value="">Tous les rôles</option>
         <option value="admin" {{#if (isEqual filters.role 'admin')}}selected{{/if}}>Admin</option>
         <option value="ofs" {{#if (isEqual filters.role 'ofs')}}selected{{/if}}>OFS</option>
+        <option value="commercialisateur" {{#if (isEqual filters.role 'commercialisateur')}}selected{{/if}}>Commercialisateur</option>
       </select>
     </div>
 
@@ -87,7 +88,7 @@
           </td>
           <td class="px-4 py-3">
             <span class="inline-flex rounded-full bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-300">
-              {{#each user.roles as |role|}}{{#if @first}}{{#if (isEqual role 'admin')}}Admin{{else}}OFS{{/if}}{{/if}}{{/each}}
+              {{#each user.roles as |role|}}{{#if @first}}{{#if (isEqual role 'admin')}}Admin{{else if (isEqual role 'commercialisateur')}}Commercialisateur{{else}}OFS{{/if}}{{/if}}{{/each}}
             </span>
           </td>
           <td class="px-4 py-3">
@@ -109,7 +110,11 @@
               {{/each}}
             </div>
             {{else}}
+            {{#if user.distributor}}
+            <span class="inline-flex rounded-full bg-orange-50 px-2.5 py-0.5 text-xs font-medium text-orange-800 dark:bg-orange-900 dark:text-orange-300">{{user.distributor.name}}</span>
+            {{else}}
             <span class="text-gray-500 dark:text-gray-400">-</span>
+            {{/if}}
             {{/if}}
           </td>
           <td class="px-4 py-3 text-right">

--- a/apps/backend/src/views/users/update.hbs
+++ b/apps/backend/src/views/users/update.hbs
@@ -54,11 +54,31 @@
           </select>
         </div>
 
+        <div id="distributor-section" class="mt-6 {{#if (isEqual form.role 'commercialisateur')}}block{{else}}hidden{{/if}}">
+          <label for="distributorId" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Commercialisateur rattaché</label>
+          <select name="distributorId" id="distributorId"
+            class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-600 focus:border-primary-600 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:text-white">
+            <option value="">Sélectionner un commercialisateur</option>
+            {{#each distributors as |distributor|}}
+            <option value="{{distributor.id}}" {{#if (isEqual ../form.distributorId distributor.id)}}selected{{/if}}>{{distributor.name}}</option>
+            {{/each}}
+          </select>
+        </div>
+
         <div class="mt-6 flex items-center gap-3">
           <button type="submit" class="text-white inline-flex items-center bg-primary-700 hover:bg-primary-800 focus:ring-4 focus:outline-none focus:ring-primary-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-primary-600 dark:hover:bg-primary-700 dark:focus:ring-primary-800">Enregistrer</button>
           <a href="{{backHref}}" class="text-sm font-medium text-gray-700 hover:underline dark:text-gray-200">Retour à la liste</a>
         </div>
       </form>
+    </section>
+
+    <section class="rounded-lg bg-white p-6 shadow-md dark:bg-gray-800">
+      <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Commercialisateur rattaché</h2>
+      {{#if user.distributor}}
+      <p class="mt-4 text-sm text-gray-700 dark:text-gray-300">{{user.distributor.name}}</p>
+      {{else}}
+      <p class="mt-4 text-sm text-gray-500 dark:text-gray-400">Aucun commercialisateur rattaché.</p>
+      {{/if}}
     </section>
 
     <section class="rounded-lg bg-white p-6 shadow-md dark:bg-gray-800">
@@ -115,18 +135,26 @@
     const roleField = document.getElementById('role');
     const ofsSection = document.getElementById('ofs-section');
     const ofsSelect = document.getElementById('ofsIds');
+    const distributorSection = document.getElementById('distributor-section');
+    const distributorSelect = document.getElementById('distributorId');
     const copyButton = document.querySelector('[data-password-copy]');
     const copyFeedback = document.getElementById('copy-feedback');
     const updateForm = document.getElementById('user-update-form');
 
     const sync = () => {
       const show = roleField?.value === 'ofs';
+      const showDistributor = roleField?.value === 'commercialisateur';
       ofsSection?.classList.toggle('hidden', !show);
       ofsSection?.classList.toggle('block', show);
+      distributorSection?.classList.toggle('hidden', !showDistributor);
+      distributorSection?.classList.toggle('block', showDistributor);
       if (!show && ofsSelect instanceof HTMLSelectElement) {
         Array.from(ofsSelect.options).forEach((option) => {
           option.selected = false;
         });
+      }
+      if (!showDistributor && distributorSelect instanceof HTMLSelectElement) {
+        distributorSelect.value = '';
       }
     };
 

--- a/apps/backend/test/infrastructure/auth/guards/portal-api-authenticated.guard.unit-spec.ts
+++ b/apps/backend/test/infrastructure/auth/guards/portal-api-authenticated.guard.unit-spec.ts
@@ -1,0 +1,38 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { UserRole } from 'src/domain/user/user-role.enum';
+import { PortalApiAuthenticatedGuard } from 'src/infrastructure/auth/guards/portal-api-authenticated.guard';
+
+const buildContext = (request: unknown) =>
+  ({
+    switchToHttp: () => ({
+      getRequest: () => request,
+    }),
+  }) as ExecutionContext;
+
+describe('PortalApiAuthenticatedGuard', () => {
+  const guard = new PortalApiAuthenticatedGuard();
+
+  it('allows active commercialisateur portal users', () => {
+    const context = buildContext({
+      isAuthenticated: () => true,
+      user: {
+        isActive: true,
+        roles: [UserRole.DISTRIBUTOR],
+      },
+    });
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('rejects authenticated users without a portal role', () => {
+    const context = buildContext({
+      isAuthenticated: () => true,
+      user: {
+        isActive: true,
+        roles: [],
+      },
+    });
+
+    expect(() => guard.canActivate(context)).toThrow(UnauthorizedException);
+  });
+});

--- a/apps/ofs-portal/src/app.d.ts
+++ b/apps/ofs-portal/src/app.d.ts
@@ -26,6 +26,11 @@ declare global {
         regions?: string[];
         departements?: string[];
       }[];
+      distributorSelectableOfss?: {
+        id: string;
+        name: string;
+      }[];
+      selectedDistributorOfsId?: string;
       currentOfs?: { id: string; name: string } | null;
       isAuthenticatedApp?: boolean;
     }

--- a/apps/ofs-portal/src/app.d.ts
+++ b/apps/ofs-portal/src/app.d.ts
@@ -17,6 +17,7 @@ declare global {
         roles: string[];
         canAccessAllOfss: boolean;
         ofss: { id: string; name: string }[];
+        distributor?: { id: string; name: string } | null;
       } | null;
       selectableOfss?: {
         id: string;

--- a/apps/ofs-portal/src/lib/server/auth.ts
+++ b/apps/ofs-portal/src/lib/server/auth.ts
@@ -7,6 +7,7 @@ export type PortalUser = {
   roles: string[];
   canAccessAllOfss: boolean;
   ofss: { id: string; name: string }[];
+  distributor?: { id: string; name: string } | null;
 };
 
 export function isSafePortalReturnTo(
@@ -16,6 +17,10 @@ export function isSafePortalReturnTo(
 }
 
 export function resolvePortalEntry(user: PortalUser): string {
+  if (user.roles.includes("commercialisateur")) {
+    return "/commercialisateur";
+  }
+
   if (user.canAccessAllOfss) {
     return "/selection-ofs";
   }

--- a/apps/ofs-portal/src/routes/(app)/+layout.server.ts
+++ b/apps/ofs-portal/src/routes/(app)/+layout.server.ts
@@ -9,7 +9,10 @@ export const load: ServerLoad = async (event) => {
 
   let selectableOfss: App.PageData["selectableOfss"] = [];
 
-  if (authenticatedUser.canAccessAllOfss || authenticatedUser.ofss.length > 1) {
+  if (
+    !authenticatedUser.roles.includes("commercialisateur") &&
+    (authenticatedUser.canAccessAllOfss || authenticatedUser.ofss.length > 1)
+  ) {
     const response = await backendFetch(event, "/api/portal/ofss");
     selectableOfss = response.ok ? await readJson(response) : [];
   }

--- a/apps/ofs-portal/src/routes/(app)/+layout.server.ts
+++ b/apps/ofs-portal/src/routes/(app)/+layout.server.ts
@@ -8,10 +8,28 @@ export const load: ServerLoad = async (event) => {
   const authenticatedUser = user!;
 
   let selectableOfss: App.PageData["selectableOfss"] = [];
+  let distributorSelectableOfss: App.PageData["distributorSelectableOfss"] = [];
 
-  if (
-    !authenticatedUser.roles.includes("commercialisateur") &&
-    (authenticatedUser.canAccessAllOfss || authenticatedUser.ofss.length > 1)
+  if (authenticatedUser.roles.includes("commercialisateur")) {
+    const response = await backendFetch(
+      event,
+      "/api/portal/ofss/commercialisateur/ofss",
+    );
+    distributorSelectableOfss = response.ok
+      ? (
+          await readJson<
+            {
+              ofs: {
+                id: string;
+                name: string;
+              };
+            }[]
+          >(response)
+        ).map((relationship) => relationship.ofs)
+      : [];
+  } else if (
+    authenticatedUser.canAccessAllOfss ||
+    authenticatedUser.ofss.length > 1
   ) {
     const response = await backendFetch(event, "/api/portal/ofss");
     selectableOfss = response.ok ? await readJson(response) : [];
@@ -20,6 +38,8 @@ export const load: ServerLoad = async (event) => {
   return {
     user: authenticatedUser,
     selectableOfss,
+    distributorSelectableOfss,
+    selectedDistributorOfsId: event.url.searchParams.get("ofsId") || "",
     isAuthenticatedApp: true,
   };
 };

--- a/apps/ofs-portal/src/routes/(app)/+layout.svelte
+++ b/apps/ofs-portal/src/routes/(app)/+layout.svelte
@@ -8,11 +8,15 @@
   let search = $state("");
   let switcherOpen = $state(false);
 
+  const isDistributor = $derived(user.roles.includes("commercialisateur"));
   const currentOfsLabel = $derived(
-    page.data.currentOfs?.name || "Sélectionner un OFS",
+    isDistributor
+      ? user.distributor?.name || "Commercialisateur"
+      : page.data.currentOfs?.name || "Sélectionner un OFS",
   );
   const canSwitch = $derived(
-    (data.selectableOfss?.length || 0) > 1 || user.canAccessAllOfss,
+    !isDistributor &&
+      ((data.selectableOfss?.length || 0) > 1 || user.canAccessAllOfss),
   );
   const showSearch = $derived((data.selectableOfss?.length || 0) > 5);
   const filteredOfss = $derived(
@@ -76,7 +80,9 @@
             <a href="/" title="Accueil - Boris - Ministère chargé du logement">
               <p class="fr-header__service-title">BoRiS</p>
             </a>
-            <p class="fr-header__service-tagline">Espace OFS</p>
+            <p class="fr-header__service-tagline">
+              {isDistributor ? "Espace commercialisateur" : "Espace OFS"}
+            </p>
           </div>
         </div>
         <div class="fr-header__tools">
@@ -88,6 +94,11 @@
                   <span
                     class="fr-badge fr-badge--sm fr-badge--blue-cumulus fr-ml-1w"
                     >Admin</span
+                  >
+                {:else if isDistributor}
+                  <span
+                    class="fr-badge fr-badge--sm fr-badge--green-emeraude fr-ml-1w"
+                    >Commercialisateur</span
                   >
                 {/if}
               </li>
@@ -167,7 +178,28 @@
       </div>
     </div>
   </div>
-  {#if page.data.currentOfs}
+  {#if isDistributor}
+    <div class="fr-header__menu fr-modal" id="menu-modal">
+      <div class="fr-container">
+        <nav class="fr-nav" aria-label="Navigation principale commercialisateur">
+          <ul class="fr-nav__list">
+            <li class="fr-nav__item">
+              <a
+                class="fr-nav__link"
+                aria-current={page.url.pathname === "/commercialisateur"
+                  ? "page"
+                  : undefined}
+                href="/commercialisateur"
+                target="_self"
+              >
+                Transmissions
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  {:else if page.data.currentOfs}
     <div class="fr-header__menu fr-modal" id="menu-modal">
       <div class="fr-container">
         <nav class="fr-nav" aria-label="Navigation principale OFS">
@@ -184,6 +216,19 @@
                 target="_self"
               >
                 Simulations
+              </a>
+            </li>
+            <li class="fr-nav__item">
+              <a
+                class="fr-nav__link"
+                aria-current={page.url.pathname ===
+                `/ofs/${page.data.currentOfs.id}/transmissions`
+                  ? "page"
+                  : undefined}
+                href={`/ofs/${page.data.currentOfs.id}/transmissions`}
+                target="_self"
+              >
+                Transmissions
               </a>
             </li>
             <li class="fr-nav__item">

--- a/apps/ofs-portal/src/routes/(app)/+layout.svelte
+++ b/apps/ofs-portal/src/routes/(app)/+layout.svelte
@@ -9,18 +9,43 @@
   let switcherOpen = $state(false);
 
   const isDistributor = $derived(user.roles.includes("commercialisateur"));
+  const distributorCurrentOfs = $derived(
+    data.distributorSelectableOfss?.find(
+      (ofs) => ofs.id === data.selectedDistributorOfsId,
+    ),
+  );
   const currentOfsLabel = $derived(
     isDistributor
-      ? user.distributor?.name || "Commercialisateur"
+      ? distributorCurrentOfs?.name || "Tous les OFS"
       : page.data.currentOfs?.name || "Sélectionner un OFS",
   );
   const canSwitch = $derived(
     !isDistributor &&
       ((data.selectableOfss?.length || 0) > 1 || user.canAccessAllOfss),
   );
+  const canSwitchDistributorOfs = $derived(
+    isDistributor && (data.distributorSelectableOfss?.length || 0) > 0,
+  );
   const showSearch = $derived((data.selectableOfss?.length || 0) > 5);
+  const showDistributorSearch = $derived(
+    (data.distributorSelectableOfss?.length || 0) > 5,
+  );
   const filteredOfss = $derived(
     (data.selectableOfss || []).filter((ofs) =>
+      ofs.name
+        .normalize("NFD")
+        .replace(/\p{Diacritic}/gu, "")
+        .toLowerCase()
+        .includes(
+          search
+            .normalize("NFD")
+            .replace(/\p{Diacritic}/gu, "")
+            .toLowerCase(),
+        ),
+    ),
+  );
+  const filteredDistributorOfss = $derived(
+    (data.distributorSelectableOfss || []).filter((ofs) =>
       ofs.name
         .normalize("NFD")
         .replace(/\p{Diacritic}/gu, "")
@@ -168,6 +193,79 @@
                   </div>
                 </div>
               </details>
+            {:else if canSwitchDistributorOfs}
+              <details
+                bind:open={switcherOpen}
+                class="fr-mr-2w"
+                style="position: relative;"
+              >
+                <summary
+                  class="fr-btn fr-btn--secondary fr-icon-arrow-down-s-line fr-btn--icon-right"
+                  aria-label="Filtrer par OFS partenaire"
+                  style="min-width: 18rem; justify-content: space-between;"
+                >
+                  {currentOfsLabel}
+                </summary>
+
+                <div
+                  class="fr-p-2w fr-shadow-6"
+                  style="position: absolute; right: 0; top: calc(100% + 0.5rem); width: 22rem; z-index: 1000; border-radius: 0.5rem; box-sizing: border-box;"
+                  style:background="white"
+                >
+                  {#if showDistributorSearch}
+                    <div class="fr-input-group fr-mb-2w">
+                      <label
+                        class="fr-sr-only"
+                        for="distributor-ofs-switcher-search"
+                        >Rechercher un OFS</label
+                      >
+                      <input
+                        id="distributor-ofs-switcher-search"
+                        class="fr-input"
+                        type="search"
+                        bind:value={search}
+                        placeholder="Rechercher un OFS"
+                      />
+                    </div>
+                  {/if}
+
+                  <div style="max-height: 18rem; overflow-y: auto;">
+                    <ul class="fr-menu__list">
+                      <li>
+                        <a
+                          class="fr-nav__link"
+                          aria-current={data.selectedDistributorOfsId
+                            ? undefined
+                            : "page"}
+                          href="/commercialisateur"
+                          onclick={closeSwitcher}>Tous les OFS</a
+                        >
+                      </li>
+                      {#if filteredDistributorOfss.length === 0}
+                        <li>
+                          <p class="fr-text--sm fr-mb-0 fr-px-2w">
+                            Aucun OFS ne correspond à votre recherche.
+                          </p>
+                        </li>
+                      {:else}
+                        {#each filteredDistributorOfss as ofs}
+                          <li>
+                            <a
+                              class="fr-nav__link"
+                              aria-current={data.selectedDistributorOfsId ===
+                              ofs.id
+                                ? "page"
+                                : undefined}
+                              href={`/commercialisateur?ofsId=${ofs.id}`}
+                              onclick={closeSwitcher}>{ofs.name}</a
+                            >
+                          </li>
+                        {/each}
+                      {/if}
+                    </ul>
+                  </div>
+                </div>
+              </details>
             {:else if page.data.currentOfs}
               <span class="fr-mr-2w fr-text--sm"
                 >{page.data.currentOfs.name}</span
@@ -181,7 +279,10 @@
   {#if isDistributor}
     <div class="fr-header__menu fr-modal" id="menu-modal">
       <div class="fr-container">
-        <nav class="fr-nav" aria-label="Navigation principale commercialisateur">
+        <nav
+          class="fr-nav"
+          aria-label="Navigation principale commercialisateur"
+        >
           <ul class="fr-nav__list">
             <li class="fr-nav__item">
               <a
@@ -192,7 +293,7 @@
                 href="/commercialisateur"
                 target="_self"
               >
-                Transmissions
+                Mes contacts
               </a>
             </li>
           </ul>

--- a/apps/ofs-portal/src/routes/(app)/commercialisateur/+page.server.ts
+++ b/apps/ofs-portal/src/routes/(app)/commercialisateur/+page.server.ts
@@ -10,8 +10,17 @@ type ContactLine = {
   phone: string | null;
   departementCode: string | null;
   city: string | null;
+  contribution: number | null;
+  householdSize: number | null;
+  hasDisability: boolean | null;
+  taxableIncome: number | null;
+  propertySituation: string | null;
+  housingType: string | null;
+  resources: number | null;
   action: string | null;
   status: string | null;
+  isNew: boolean;
+  transmittedDistributors: { id: string; name: string }[];
   ofs: {
     id: string;
     name: string;
@@ -23,7 +32,8 @@ type ContactLine = {
 
 export const load: ServerLoad = async (event) => {
   const { parent, url } = event;
-  const { user } = await parent();
+  const parentData = await parent();
+  const { user } = parentData;
 
   if (!user?.roles.includes("commercialisateur")) {
     throw redirect(303, "/");
@@ -37,30 +47,18 @@ export const load: ServerLoad = async (event) => {
     query.set("ofsId", ofsId);
   }
 
-  const [ofssResponse, contactsResponse] = await Promise.all([
-    backendFetch(event, "/api/portal/ofss/commercialisateur/ofss"),
-    backendFetch(
-      event,
-      `/api/portal/ofss/commercialisateur/eligibility-simulations?${query.toString()}`,
-    ),
-  ]);
+  const contactsResponse = await backendFetch(
+    event,
+    `/api/portal/ofss/commercialisateur/eligibility-simulations?${query.toString()}`,
+  );
 
   return {
     distributor: user.distributor,
-    relationships: ofssResponse.ok
-      ? await readJson<
-          {
-            transmissionId: string;
-            ofs: {
-              id: string;
-              name: string;
-              email: string | null;
-              phone: string | null;
-              websiteUrl: string | null;
-            };
-          }[]
-        >(ofssResponse)
-      : [],
+    relationships: (parentData.distributorSelectableOfss || []).map(
+      (ofs: { id: string; name: string }) => ({
+        ofs,
+      }),
+    ),
     contacts: contactsResponse.ok
       ? await readJson<{
           items: ContactLine[];

--- a/apps/ofs-portal/src/routes/(app)/commercialisateur/+page.server.ts
+++ b/apps/ofs-portal/src/routes/(app)/commercialisateur/+page.server.ts
@@ -1,0 +1,85 @@
+import { backendFetch, readJson } from "$lib/server/backend";
+import { redirect, type ServerLoad } from "@sveltejs/kit";
+
+type ContactLine = {
+  simulationId: string;
+  locationId: string;
+  submittedAt: string;
+  fullName: string | null;
+  email: string | null;
+  phone: string | null;
+  departementCode: string | null;
+  city: string | null;
+  action: string | null;
+  status: string | null;
+  ofs: {
+    id: string;
+    name: string;
+    email: string | null;
+    phone: string | null;
+    websiteUrl: string | null;
+  } | null;
+};
+
+export const load: ServerLoad = async (event) => {
+  const { parent, url } = event;
+  const { user } = await parent();
+
+  if (!user?.roles.includes("commercialisateur")) {
+    throw redirect(303, "/");
+  }
+
+  const page = Number(url.searchParams.get("page") || "1");
+  const ofsId = url.searchParams.get("ofsId") || "";
+  const query = new URLSearchParams({ page: `${page}`, pageSize: "20" });
+
+  if (ofsId) {
+    query.set("ofsId", ofsId);
+  }
+
+  const [ofssResponse, contactsResponse] = await Promise.all([
+    backendFetch(event, "/api/portal/ofss/commercialisateur/ofss"),
+    backendFetch(
+      event,
+      `/api/portal/ofss/commercialisateur/eligibility-simulations?${query.toString()}`,
+    ),
+  ]);
+
+  return {
+    distributor: user.distributor,
+    relationships: ofssResponse.ok
+      ? await readJson<
+          {
+            transmissionId: string;
+            ofs: {
+              id: string;
+              name: string;
+              email: string | null;
+              phone: string | null;
+              websiteUrl: string | null;
+            };
+          }[]
+        >(ofssResponse)
+      : [],
+    contacts: contactsResponse.ok
+      ? await readJson<{
+          items: ContactLine[];
+          totalCount: number;
+          page: number;
+          pageSize: number;
+          pagesCount: number;
+          hasPreviousPage: boolean;
+          hasNextPage: boolean;
+        }>(contactsResponse)
+      : {
+          items: [],
+          totalCount: 0,
+          page,
+          pageSize: 20,
+          pagesCount: 0,
+          hasPreviousPage: false,
+          hasNextPage: false,
+        },
+    selectedOfsId: ofsId,
+  };
+};

--- a/apps/ofs-portal/src/routes/(app)/commercialisateur/+page.svelte
+++ b/apps/ofs-portal/src/routes/(app)/commercialisateur/+page.svelte
@@ -22,10 +22,13 @@
     { value: "HAS_SIGNED_BRS", label: "a signé un BRS" },
   ] as const;
 
-  let items = $state<ContactLine[]>(data.contacts.items.map((line) => ({ ...line })));
+  let items = $state<ContactLine[]>(
+    data.contacts.items.map((line) => ({ ...line })),
+  );
   let savingBySimulationId = $state<Record<string, boolean>>({});
   let startDate = $state("");
   let endDate = $state("");
+  let exportError = $state("");
   let exportDialog: HTMLDialogElement | undefined;
 
   $effect(() => {
@@ -40,11 +43,65 @@
     }).format(new Date(value));
   }
 
+  function formatCurrency(value: number) {
+    return new Intl.NumberFormat("fr-FR", {
+      style: "currency",
+      currency: "EUR",
+      maximumFractionDigits: 0,
+    }).format(value);
+  }
+
+  function formatPropertySituation(value: string | null) {
+    switch (value) {
+      case "PROPRIETAIRE":
+        return "Propriétaire d'un logement";
+      case "LOCATAIRE_SOCIAL":
+        return "Locataire d'un logement social";
+      case "LOCATAIRE_PRIVE":
+        return "Locataire d'un logement privé";
+      case "HEBERGE":
+        return "Hébergé·e";
+      case "AUTRE":
+        return "Autre";
+      default:
+        return value || "-";
+    }
+  }
+
   function pageHref(page: number) {
     const params = new URLSearchParams();
     if (page > 1) params.set("page", `${page}`);
     if (data.selectedOfsId) params.set("ofsId", data.selectedOfsId);
     return params.toString() ? `?${params.toString()}` : "";
+  }
+
+  function openExportDialog() {
+    exportError = "";
+    exportDialog?.showModal();
+  }
+
+  function closeExportDialog() {
+    exportError = "";
+    exportDialog?.close();
+  }
+
+  function handleExportSubmit(event: SubmitEvent) {
+    const form = event.currentTarget as HTMLFormElement;
+
+    if (!form.reportValidity()) {
+      event.preventDefault();
+      return;
+    }
+
+    if (startDate > endDate) {
+      event.preventDefault();
+      exportError =
+        "La date de début doit être antérieure ou égale à la date de fin.";
+      return;
+    }
+
+    exportError = "";
+    exportDialog?.close();
   }
 
   async function updateMetadata(
@@ -81,100 +138,170 @@
 </script>
 
 <svelte:head>
-  <title>Transmissions - Espace commercialisateur - BoRiS</title>
+  <title>Mes contacts - Espace commercialisateur - BoRiS</title>
 </svelte:head>
 
 <div class="fr-grid-row">
   <div class="fr-col">
-    <h1 class="fr-h3">Transmissions commerciales</h1>
+    <h1 class="fr-h3">Mes contacts</h1>
     <p class="fr-text--sm">{data.distributor?.name}</p>
   </div>
   <div class="fr-col-2 text-right">
-    <button class="fr-btn fr-btn--secondary fr-mb-3w" type="button" onclick={() => exportDialog?.showModal()}>
+    <button
+      class="fr-btn fr-btn--secondary fr-mb-3w"
+      type="button"
+      onclick={openExportDialog}
+    >
       Exporter en CSV
     </button>
   </div>
 </div>
 
-<dialog bind:this={exportDialog} class="export-dialog">
-  <form method="GET" action="/commercialisateur/export">
+<dialog
+  bind:this={exportDialog}
+  class="export-dialog"
+  aria-labelledby="export-dialog-title"
+>
+  <form
+    method="GET"
+    action="/commercialisateur/export"
+    onsubmit={handleExportSubmit}
+  >
     <input type="hidden" name="ofsId" value={data.selectedOfsId} />
-    <h2 class="fr-h5 fr-mb-2w">Exporter des lignes</h2>
-    <label class="fr-label" for="startDate">Date de début</label>
-    <input class="fr-input fr-mb-2w" id="startDate" type="date" name="startDate" bind:value={startDate} required />
-    <label class="fr-label" for="endDate">Date de fin</label>
-    <input class="fr-input fr-mb-2w" id="endDate" type="date" name="endDate" bind:value={endDate} required />
-    <button class="fr-btn" type="submit">Télécharger</button>
-    <button class="fr-btn fr-btn--secondary" type="button" onclick={() => exportDialog?.close()}>Annuler</button>
+    <h2 class="fr-h5 fr-mb-2w" id="export-dialog-title">Exporter des lignes</h2>
+
+    <div class="fr-input-group fr-mb-2w">
+      <label class="fr-label" for="export-start-date">Date de début</label>
+      <input
+        class="fr-input"
+        id="export-start-date"
+        type="date"
+        name="startDate"
+        bind:value={startDate}
+        max={endDate || undefined}
+        required
+      />
+    </div>
+
+    <div class="fr-input-group fr-mb-2w">
+      <label class="fr-label" for="export-end-date">Date de fin</label>
+      <input
+        class="fr-input"
+        id="export-end-date"
+        type="date"
+        name="endDate"
+        bind:value={endDate}
+        min={startDate || undefined}
+        required
+      />
+    </div>
+
+    {#if exportError}
+      <div class="fr-alert fr-alert--error fr-mb-2w">
+        <p>{exportError}</p>
+      </div>
+    {/if}
+
+    <div class="export-dialog__actions">
+      <button class="fr-btn" type="submit">Télécharger le CSV</button>
+      <button
+        class="fr-btn fr-btn--secondary"
+        type="button"
+        onclick={closeExportDialog}>Annuler</button
+      >
+    </div>
   </form>
 </dialog>
 
-<section class="fr-mb-3w">
-  {#if data.relationships.length}
-    <form method="GET">
-      <label class="fr-label" for="ofsId">OFS partenaire</label>
-      <select class="fr-select" id="ofsId" name="ofsId" onchange={(event) => (event.currentTarget as HTMLSelectElement).form?.submit()}>
-        <option value="">Tous les OFS</option>
-        {#each data.relationships as relationship}
-          <option value={relationship.ofs.id} selected={data.selectedOfsId === relationship.ofs.id}>
-            {relationship.ofs.name}
-          </option>
-        {/each}
-      </select>
-    </form>
-  {:else}
-    <div class="fr-alert fr-alert--info">
-      <p>Aucune transmission active pour le moment.</p>
-    </div>
-  {/if}
-</section>
-
-{#if data.relationships.length}
-  <div class="fr-grid-row fr-grid-row--gutters fr-mb-3w">
-    {#each data.relationships as relationship}
-      <section class="fr-col-12 fr-col-md-4">
-        <div class="relationship">
-          <h2 class="fr-h6">{relationship.ofs.name}</h2>
-          <p class="fr-text--sm">{relationship.ofs.email || "-"}<br />{relationship.ofs.phone || "-"}</p>
-          {#if relationship.ofs.websiteUrl}
-            <a class="fr-link" href={relationship.ofs.websiteUrl} target="_blank" rel="noreferrer">Site web</a>
-          {/if}
-        </div>
-      </section>
-    {/each}
-  </div>
-{/if}
-
 {#if items.length}
-  <div class="fr-table fr-table--bordered">
+  <div class="fr-table fr-table--bordered contacts-table">
     <table>
       <caption>{data.contacts.totalCount} contact(s)</caption>
       <thead>
         <tr>
           <th scope="col">Suivi</th>
-          <th scope="col">OFS</th>
+          {#if !data.selectedOfsId}
+            <th scope="col">OFS</th>
+          {/if}
           <th scope="col">Date</th>
           <th scope="col">Contact</th>
           <th scope="col">Localisation</th>
+          <th scope="col">Foyer</th>
+          <th scope="col">Projet</th>
+          <th scope="col">Ressources</th>
         </tr>
       </thead>
       <tbody>
         {#each items as line}
           <tr>
             <td>
-              <select class="fr-select fr-mb-1w" bind:value={line.action} disabled={savingBySimulationId[line.simulationId]} onchange={(event) => updateMetadata(line, { action: (event.currentTarget as HTMLSelectElement).value || null })}>
+              <select
+                class="fr-select fr-mb-1w"
+                bind:value={line.action}
+                disabled={savingBySimulationId[line.simulationId]}
+                onchange={(event) =>
+                  updateMetadata(line, {
+                    action:
+                      (event.currentTarget as HTMLSelectElement).value || null,
+                  })}
+              >
                 <option value="">Action</option>
-                {#each actionOptions as option}<option value={option.value}>{option.label}</option>{/each}
+                {#each actionOptions as option}<option value={option.value}
+                    >{option.label}</option
+                  >{/each}
               </select>
-              <select class="fr-select" bind:value={line.status} disabled={savingBySimulationId[line.simulationId]} onchange={(event) => updateMetadata(line, { status: (event.currentTarget as HTMLSelectElement).value || null })}>
+              <select
+                class="fr-select"
+                bind:value={line.status}
+                disabled={savingBySimulationId[line.simulationId]}
+                onchange={(event) =>
+                  updateMetadata(line, {
+                    status:
+                      (event.currentTarget as HTMLSelectElement).value || null,
+                  })}
+              >
                 <option value="">Statut</option>
-                {#each statusOptions as option}<option value={option.value}>{option.label}</option>{/each}
+                {#each statusOptions as option}<option value={option.value}
+                    >{option.label}</option
+                  >{/each}
               </select>
             </td>
-            <td>{line.ofs?.name || "-"}</td>
+            {#if !data.selectedOfsId}
+              <td>{line.ofs?.name || "-"}</td>
+            {/if}
             <td>{formatDate(line.submittedAt)}</td>
-            <td><strong>{line.fullName || "Contact sans nom"}</strong><br />{line.email || "-"}<br />{line.phone || "-"}</td>
-            <td>{line.city || "-"}<br />{line.departementCode ? `Département ${line.departementCode}` : "-"}</td>
+            <td
+              ><strong>{line.fullName || "Contact sans nom"}</strong><br
+              />{line.email || "-"}<br />{line.phone || "-"}</td
+            >
+            <td
+              >{line.city || "-"}<br />{line.departementCode
+                ? `Département ${line.departementCode}`
+                : "-"}</td
+            >
+            <td>
+              {line.householdSize ?? "-"} personne(s)<br />
+              Handicap: {line.hasDisability === null
+                ? "-"
+                : line.hasDisability
+                  ? "Oui"
+                  : "Non"}
+            </td>
+            <td>
+              {formatPropertySituation(line.propertySituation)}<br />
+              {line.housingType || "-"}<br />
+              Apport: {line.contribution
+                ? formatCurrency(line.contribution)
+                : "-"}
+            </td>
+            <td>
+              Revenus imposables: {line.taxableIncome
+                ? formatCurrency(line.taxableIncome)
+                : "-"}<br />
+              Ressources: {line.resources
+                ? formatCurrency(line.resources)
+                : "-"}
+            </td>
           </tr>
         {/each}
       </tbody>
@@ -184,27 +311,68 @@
   {#if data.contacts.pagesCount > 1}
     <nav class="fr-pagination fr-mt-3w" aria-label="Pagination">
       <ul class="fr-pagination__list">
-        <li><a class="fr-pagination__link fr-pagination__link--prev" href={pageHref(data.contacts.page - 1)} aria-disabled={!data.contacts.hasPreviousPage}>Précédent</a></li>
-        <li><a class="fr-pagination__link fr-pagination__link--next" href={pageHref(data.contacts.page + 1)} aria-disabled={!data.contacts.hasNextPage}>Suivant</a></li>
+        <li>
+          <a
+            class="fr-pagination__link fr-pagination__link--prev"
+            href={pageHref(data.contacts.page - 1)}
+            aria-disabled={!data.contacts.hasPreviousPage}>Précédent</a
+          >
+        </li>
+        <li>
+          <a
+            class="fr-pagination__link fr-pagination__link--next"
+            href={pageHref(data.contacts.page + 1)}
+            aria-disabled={!data.contacts.hasNextPage}>Suivant</a
+          >
+        </li>
       </ul>
     </nav>
   {/if}
 {:else if data.relationships.length}
-  <div class="fr-alert fr-alert--info"><p>Aucune ligne de contact ne correspond au périmètre actif.</p></div>
+  <div class="fr-alert fr-alert--info">
+    <p>Aucune ligne de contact ne correspond au périmètre actif.</p>
+  </div>
+{:else}
+  <div class="fr-alert fr-alert--info">
+    <p>Aucune transmission active pour le moment.</p>
+  </div>
 {/if}
 
 <style>
-  .relationship {
-    background: white;
-    border-radius: 0.5rem;
-    min-height: 9rem;
-    padding: 1rem;
-  }
-
   .export-dialog {
     border: 0;
-    border-radius: 0.5rem;
-    max-width: 26rem;
+    border-radius: 1rem;
+    max-width: 32rem;
+    padding: 0;
+    width: calc(100% - 2rem);
+  }
+
+  .export-dialog::backdrop {
+    background: rgb(0 0 0 / 45%);
+  }
+
+  .export-dialog form {
     padding: 2rem;
+  }
+
+  .export-dialog__actions {
+    display: flex;
+    gap: 1rem;
+    justify-content: flex-end;
+  }
+
+  .contacts-table {
+    width: 100%;
+  }
+
+  .contacts-table :global(table) {
+    min-width: 78rem;
+    width: 100%;
+  }
+
+  @media (max-width: 48rem) {
+    .export-dialog__actions {
+      flex-direction: column;
+    }
   }
 </style>

--- a/apps/ofs-portal/src/routes/(app)/commercialisateur/+page.svelte
+++ b/apps/ofs-portal/src/routes/(app)/commercialisateur/+page.svelte
@@ -1,0 +1,210 @@
+<script lang="ts">
+  let { data } = $props();
+
+  type ContactLine = (typeof data.contacts.items)[number];
+  type SimulationMetadata = {
+    simulationId: string;
+    action: string | null;
+    status: string | null;
+  };
+
+  const actionOptions = [
+    { value: "RECONTACTED", label: "recontacté" },
+    { value: "NOT_RECONTACTED", label: "pas recontacté" },
+  ] as const;
+
+  const statusOptions = [
+    { value: "NOT_INTERESTED", label: "pas intéressé" },
+    { value: "NO_RESPONSE", label: "ne répond pas" },
+    { value: "EXCHANGE_IN_PROGRESS", label: "échange en cours" },
+    { value: "NOT_FINANCEABLE", label: "non solvable" },
+    { value: "WAITING_FOR_LOAN", label: "attente de prêt" },
+    { value: "HAS_SIGNED_BRS", label: "a signé un BRS" },
+  ] as const;
+
+  let items = $state<ContactLine[]>(data.contacts.items.map((line) => ({ ...line })));
+  let savingBySimulationId = $state<Record<string, boolean>>({});
+  let startDate = $state("");
+  let endDate = $state("");
+  let exportDialog: HTMLDialogElement | undefined;
+
+  $effect(() => {
+    items = data.contacts.items.map((line) => ({ ...line }));
+    savingBySimulationId = {};
+  });
+
+  function formatDate(value: string) {
+    return new Intl.DateTimeFormat("fr-FR", {
+      dateStyle: "short",
+      timeStyle: "short",
+    }).format(new Date(value));
+  }
+
+  function pageHref(page: number) {
+    const params = new URLSearchParams();
+    if (page > 1) params.set("page", `${page}`);
+    if (data.selectedOfsId) params.set("ofsId", data.selectedOfsId);
+    return params.toString() ? `?${params.toString()}` : "";
+  }
+
+  async function updateMetadata(
+    line: ContactLine,
+    updates: Partial<Pick<ContactLine, "action" | "status">>,
+  ) {
+    const previousAction = line.action;
+    const previousStatus = line.status;
+    if ("action" in updates) line.action = updates.action ?? null;
+    if ("status" in updates) line.status = updates.status ?? null;
+    savingBySimulationId[line.simulationId] = true;
+
+    try {
+      const response = await fetch(
+        `/commercialisateur/simulations/${line.simulationId}/metadata`,
+        {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ action: line.action, status: line.status }),
+        },
+      );
+
+      if (!response.ok) throw new Error();
+      const saved = (await response.json()) as SimulationMetadata;
+      line.action = saved.action;
+      line.status = saved.status;
+    } catch {
+      line.action = previousAction;
+      line.status = previousStatus;
+    } finally {
+      savingBySimulationId[line.simulationId] = false;
+    }
+  }
+</script>
+
+<svelte:head>
+  <title>Transmissions - Espace commercialisateur - BoRiS</title>
+</svelte:head>
+
+<div class="fr-grid-row">
+  <div class="fr-col">
+    <h1 class="fr-h3">Transmissions commerciales</h1>
+    <p class="fr-text--sm">{data.distributor?.name}</p>
+  </div>
+  <div class="fr-col-2 text-right">
+    <button class="fr-btn fr-btn--secondary fr-mb-3w" type="button" onclick={() => exportDialog?.showModal()}>
+      Exporter en CSV
+    </button>
+  </div>
+</div>
+
+<dialog bind:this={exportDialog} class="export-dialog">
+  <form method="GET" action="/commercialisateur/export">
+    <input type="hidden" name="ofsId" value={data.selectedOfsId} />
+    <h2 class="fr-h5 fr-mb-2w">Exporter des lignes</h2>
+    <label class="fr-label" for="startDate">Date de début</label>
+    <input class="fr-input fr-mb-2w" id="startDate" type="date" name="startDate" bind:value={startDate} required />
+    <label class="fr-label" for="endDate">Date de fin</label>
+    <input class="fr-input fr-mb-2w" id="endDate" type="date" name="endDate" bind:value={endDate} required />
+    <button class="fr-btn" type="submit">Télécharger</button>
+    <button class="fr-btn fr-btn--secondary" type="button" onclick={() => exportDialog?.close()}>Annuler</button>
+  </form>
+</dialog>
+
+<section class="fr-mb-3w">
+  {#if data.relationships.length}
+    <form method="GET">
+      <label class="fr-label" for="ofsId">OFS partenaire</label>
+      <select class="fr-select" id="ofsId" name="ofsId" onchange={(event) => (event.currentTarget as HTMLSelectElement).form?.submit()}>
+        <option value="">Tous les OFS</option>
+        {#each data.relationships as relationship}
+          <option value={relationship.ofs.id} selected={data.selectedOfsId === relationship.ofs.id}>
+            {relationship.ofs.name}
+          </option>
+        {/each}
+      </select>
+    </form>
+  {:else}
+    <div class="fr-alert fr-alert--info">
+      <p>Aucune transmission active pour le moment.</p>
+    </div>
+  {/if}
+</section>
+
+{#if data.relationships.length}
+  <div class="fr-grid-row fr-grid-row--gutters fr-mb-3w">
+    {#each data.relationships as relationship}
+      <section class="fr-col-12 fr-col-md-4">
+        <div class="relationship">
+          <h2 class="fr-h6">{relationship.ofs.name}</h2>
+          <p class="fr-text--sm">{relationship.ofs.email || "-"}<br />{relationship.ofs.phone || "-"}</p>
+          {#if relationship.ofs.websiteUrl}
+            <a class="fr-link" href={relationship.ofs.websiteUrl} target="_blank" rel="noreferrer">Site web</a>
+          {/if}
+        </div>
+      </section>
+    {/each}
+  </div>
+{/if}
+
+{#if items.length}
+  <div class="fr-table fr-table--bordered">
+    <table>
+      <caption>{data.contacts.totalCount} contact(s)</caption>
+      <thead>
+        <tr>
+          <th scope="col">Suivi</th>
+          <th scope="col">OFS</th>
+          <th scope="col">Date</th>
+          <th scope="col">Contact</th>
+          <th scope="col">Localisation</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each items as line}
+          <tr>
+            <td>
+              <select class="fr-select fr-mb-1w" bind:value={line.action} disabled={savingBySimulationId[line.simulationId]} onchange={(event) => updateMetadata(line, { action: (event.currentTarget as HTMLSelectElement).value || null })}>
+                <option value="">Action</option>
+                {#each actionOptions as option}<option value={option.value}>{option.label}</option>{/each}
+              </select>
+              <select class="fr-select" bind:value={line.status} disabled={savingBySimulationId[line.simulationId]} onchange={(event) => updateMetadata(line, { status: (event.currentTarget as HTMLSelectElement).value || null })}>
+                <option value="">Statut</option>
+                {#each statusOptions as option}<option value={option.value}>{option.label}</option>{/each}
+              </select>
+            </td>
+            <td>{line.ofs?.name || "-"}</td>
+            <td>{formatDate(line.submittedAt)}</td>
+            <td><strong>{line.fullName || "Contact sans nom"}</strong><br />{line.email || "-"}<br />{line.phone || "-"}</td>
+            <td>{line.city || "-"}<br />{line.departementCode ? `Département ${line.departementCode}` : "-"}</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+
+  {#if data.contacts.pagesCount > 1}
+    <nav class="fr-pagination fr-mt-3w" aria-label="Pagination">
+      <ul class="fr-pagination__list">
+        <li><a class="fr-pagination__link fr-pagination__link--prev" href={pageHref(data.contacts.page - 1)} aria-disabled={!data.contacts.hasPreviousPage}>Précédent</a></li>
+        <li><a class="fr-pagination__link fr-pagination__link--next" href={pageHref(data.contacts.page + 1)} aria-disabled={!data.contacts.hasNextPage}>Suivant</a></li>
+      </ul>
+    </nav>
+  {/if}
+{:else if data.relationships.length}
+  <div class="fr-alert fr-alert--info"><p>Aucune ligne de contact ne correspond au périmètre actif.</p></div>
+{/if}
+
+<style>
+  .relationship {
+    background: white;
+    border-radius: 0.5rem;
+    min-height: 9rem;
+    padding: 1rem;
+  }
+
+  .export-dialog {
+    border: 0;
+    border-radius: 0.5rem;
+    max-width: 26rem;
+    padding: 2rem;
+  }
+</style>

--- a/apps/ofs-portal/src/routes/(app)/commercialisateur/export/+server.ts
+++ b/apps/ofs-portal/src/routes/(app)/commercialisateur/export/+server.ts
@@ -1,0 +1,27 @@
+import { backendFetch } from "$lib/server/backend";
+import { error, redirect, type RequestHandler } from "@sveltejs/kit";
+
+export const GET: RequestHandler = async (event) => {
+  const { url } = event;
+  const response = await backendFetch(
+    event,
+    `/api/portal/ofss/commercialisateur/eligibility-simulations/export?${url.searchParams.toString()}`,
+  );
+
+  if (response.status === 401) {
+    throw redirect(303, "/connexion");
+  }
+
+  if (!response.ok) {
+    throw error(response.status, "Export impossible");
+  }
+
+  return new Response(await response.arrayBuffer(), {
+    headers: {
+      "content-type": response.headers.get("content-type") || "text/csv",
+      "content-disposition":
+        response.headers.get("content-disposition") ||
+        'attachment; filename="transmissions-commerciales.csv"',
+    },
+  });
+};

--- a/apps/ofs-portal/src/routes/(app)/commercialisateur/simulations/[simulationId]/metadata/+server.ts
+++ b/apps/ofs-portal/src/routes/(app)/commercialisateur/simulations/[simulationId]/metadata/+server.ts
@@ -1,0 +1,24 @@
+import { backendFetch } from "$lib/server/backend";
+import { redirect, type RequestHandler } from "@sveltejs/kit";
+
+export const PUT: RequestHandler = async (event) => {
+  const body = await event.request.json();
+  const response = await backendFetch(
+    event,
+    `/api/portal/ofss/commercialisateur/eligibility-simulations/${event.params.simulationId}/metadata`,
+    {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+
+  if (response.status === 401) {
+    throw redirect(303, "/connexion");
+  }
+
+  return new Response(await response.text(), {
+    status: response.status,
+    headers: { "content-type": "application/json" },
+  });
+};

--- a/apps/ofs-portal/src/routes/(app)/ofs/[id]/simulations/+page.server.ts
+++ b/apps/ofs-portal/src/routes/(app)/ofs/[id]/simulations/+page.server.ts
@@ -20,6 +20,7 @@ type ContactLine = {
   action: string | null;
   status: string | null;
   isNew: boolean;
+  transmittedDistributors: { id: string; name: string }[];
 };
 
 type ContactPagination = {

--- a/apps/ofs-portal/src/routes/(app)/ofs/[id]/simulations/+page.svelte
+++ b/apps/ofs-portal/src/routes/(app)/ofs/[id]/simulations/+page.svelte
@@ -22,6 +22,7 @@
     action: string | null;
     status: string | null;
     isNew: boolean;
+    transmittedDistributors: { id: string; name: string }[];
   };
 
   type SimulationMetadata = {
@@ -272,6 +273,7 @@
           <th scope="col">Foyer</th>
           <th scope="col">Projet</th>
           <th scope="col">Ressources</th>
+          <th scope="col">Transmis à</th>
         </tr>
       </thead>
       <tbody>
@@ -375,6 +377,17 @@
               Ressources: {line.resources
                 ? formatCurrency(line.resources)
                 : "-"}
+            </td>
+            <td>
+              {#if line.transmittedDistributors.length}
+                <ul class="fr-tags-group">
+                  {#each line.transmittedDistributors as distributor}
+                    <li><p class="fr-tag">{distributor.name}</p></li>
+                  {/each}
+                </ul>
+              {:else}
+                -
+              {/if}
             </td>
           </tr>
         {/each}

--- a/apps/ofs-portal/src/routes/(app)/ofs/[id]/transmissions/+page.server.ts
+++ b/apps/ofs-portal/src/routes/(app)/ofs/[id]/transmissions/+page.server.ts
@@ -1,0 +1,130 @@
+import { backendFetch, readJson } from "$lib/server/backend";
+import {
+  error,
+  fail,
+  redirect,
+  type Actions,
+  type ServerLoad,
+} from "@sveltejs/kit";
+
+type Transmission = {
+  id: string;
+  distributor: { id: string; name: string };
+  isActive: boolean;
+  scopeType: "ALL" | "GEOGRAPHIC";
+  inseeCodes: string[];
+  departementCodes: string[];
+};
+
+type OfsDetail = {
+  id: string;
+  name: string;
+  distributors: { id: string; name: string }[];
+};
+
+export const load: ServerLoad = async (event) => {
+  const { parent, params, url } = event;
+  const { user } = await parent();
+  const ofsResponse = await backendFetch(
+    event,
+    `/api/portal/ofss/${params.id}`,
+  );
+
+  if (ofsResponse.status === 401) {
+    throw redirect(
+      303,
+      `/connexion?returnTo=${encodeURIComponent(url.pathname + url.search)}`,
+    );
+  }
+
+  if (ofsResponse.status === 404) {
+    throw error(404, {
+      message: "Cette page est introuvable.",
+      backHref:
+        user!.canAccessAllOfss || user!.ofss.length > 1
+          ? "/selection-ofs"
+          : "/",
+    });
+  }
+
+  const ofs = await readJson<OfsDetail>(ofsResponse);
+  const transmissionsResponse = await backendFetch(
+    event,
+    `/api/portal/ofss/${params.id}/commercial-transmissions`,
+  );
+
+  return {
+    ofs,
+    currentOfs: { id: ofs.id, name: ofs.name },
+    transmissions: transmissionsResponse.ok
+      ? await readJson<Transmission[]>(transmissionsResponse)
+      : [],
+    distributors: ofs.distributors,
+  };
+};
+
+const splitCodes = (value: FormDataEntryValue | null) =>
+  String(value || "")
+    .split(/[\s,;]+/)
+    .map((code) => code.trim())
+    .filter(Boolean);
+
+function payloadFromForm(data: FormData) {
+  const scopeType =
+    data.get("scopeType") === "GEOGRAPHIC" ? "GEOGRAPHIC" : "ALL";
+
+  return {
+    distributorId: String(data.get("distributorId") || ""),
+    isActive: data.get("isActive") === "on",
+    scopeType,
+    inseeCodes:
+      scopeType === "GEOGRAPHIC" ? splitCodes(data.get("inseeCodes")) : [],
+    departementCodes:
+      scopeType === "GEOGRAPHIC"
+        ? splitCodes(data.get("departementCodes"))
+        : [],
+  };
+}
+
+export const actions: Actions = {
+  create: async (event) => {
+    const data = await event.request.formData();
+    const response = await backendFetch(
+      event,
+      `/api/portal/ofss/${event.params.id}/commercial-transmissions`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payloadFromForm(data)),
+      },
+    );
+
+    if (!response.ok) {
+      return fail(400, { error: "La transmission n'a pas pu être créée." });
+    }
+
+    throw redirect(303, `/ofs/${event.params.id}/transmissions`);
+  },
+
+  update: async (event) => {
+    const data = await event.request.formData();
+    const transmissionId = String(data.get("transmissionId") || "");
+    const response = await backendFetch(
+      event,
+      `/api/portal/ofss/${event.params.id}/commercial-transmissions/${transmissionId}`,
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payloadFromForm(data)),
+      },
+    );
+
+    if (!response.ok) {
+      return fail(400, {
+        error: "La transmission n'a pas pu être mise à jour.",
+      });
+    }
+
+    throw redirect(303, `/ofs/${event.params.id}/transmissions`);
+  },
+};

--- a/apps/ofs-portal/src/routes/(app)/ofs/[id]/transmissions/+page.svelte
+++ b/apps/ofs-portal/src/routes/(app)/ofs/[id]/transmissions/+page.svelte
@@ -1,0 +1,275 @@
+<script lang="ts">
+  let { data, form } = $props();
+  let createScopeType = $state<"ALL" | "GEOGRAPHIC">("ALL");
+  let editScopeTypeById = $state<Record<string, "ALL" | "GEOGRAPHIC">>({});
+
+  const availableDistributors = $derived(
+    data.distributors.filter(
+      (distributor) =>
+        !data.transmissions.some(
+          (transmission) => transmission.distributor.id === distributor.id,
+        ),
+    ),
+  );
+
+  $effect(() => {
+    editScopeTypeById = Object.fromEntries(
+      data.transmissions.map((transmission) => [
+        transmission.id,
+        transmission.scopeType,
+      ]),
+    );
+  });
+
+  function codes(values: string[]) {
+    return values.join(", ");
+  }
+</script>
+
+<svelte:head>
+  <title>{data.ofs.name} - Transmissions - Espace OFS - BoRiS</title>
+</svelte:head>
+
+<div class="fr-grid-row fr-grid-row--gutters">
+  <div class="fr-col-12 fr-col-lg-7">
+    <h1 class="fr-h3">Transmissions commerciales</h1>
+    <p class="fr-text--sm">
+      Configurez les contacts transmis aux commercialisateurs pour cet OFS.
+    </p>
+  </div>
+</div>
+
+{#if form?.error}
+  <div class="fr-alert fr-alert--error fr-mb-3w"><p>{form.error}</p></div>
+{/if}
+
+<section class="fr-p-3w fr-mb-4w" style="background: white; border-radius: 0.5rem;">
+  <h2 class="fr-h5">Nouvelle transmission</h2>
+  {#if availableDistributors.length}
+    <form method="POST" action="?/create">
+      <div class="fr-grid-row fr-grid-row--gutters">
+        <div class="fr-col-12 fr-col-md-6">
+          <label class="fr-label" for="distributorId">Commercialisateur</label>
+          <select class="fr-select" id="distributorId" name="distributorId" required>
+            <option value="">Sélectionner</option>
+            {#each availableDistributors as distributor}
+              <option value={distributor.id}>{distributor.name}</option>
+            {/each}
+          </select>
+        </div>
+        <div class="fr-col-12 fr-col-md-6">
+          <label class="fr-label" for="scopeType">Périmètre</label>
+          <select
+            class="fr-select"
+            id="scopeType"
+            name="scopeType"
+            bind:value={createScopeType}
+          >
+            <option value="ALL">Tous les contacts visibles par l'OFS</option>
+            <option value="GEOGRAPHIC">Codes INSEE ou départements</option>
+          </select>
+        </div>
+      </div>
+
+      {#if createScopeType === "GEOGRAPHIC"}
+        <div class="transmission-scope fr-mt-2w">
+          <div class="fr-grid-row fr-grid-row--gutters">
+            <div class="fr-col-12 fr-col-md-6">
+              <label class="fr-label" for="inseeCodes">Codes communes INSEE</label>
+              <input
+                class="fr-input"
+                id="inseeCodes"
+                name="inseeCodes"
+                placeholder="75056, 69123"
+              />
+            </div>
+            <div class="fr-col-12 fr-col-md-6">
+              <label class="fr-label" for="departementCodes">Codes départements</label>
+              <input
+                class="fr-input"
+                id="departementCodes"
+                name="departementCodes"
+                placeholder="75, 69"
+              />
+            </div>
+          </div>
+        </div>
+      {/if}
+
+      <div class="fr-checkbox-group fr-mt-2w">
+        <input id="isActive" name="isActive" type="checkbox" checked />
+        <label class="fr-label" for="isActive">Active</label>
+      </div>
+      <button class="fr-btn fr-mt-3w" type="submit">Créer</button>
+    </form>
+  {:else}
+    <p class="fr-text--sm">
+      Tous les commercialisateurs rattachés à cet OFS ont déjà une transmission,
+      ou aucun commercialisateur n'est encore rattaché à cet OFS.
+    </p>
+  {/if}
+</section>
+
+{#if data.transmissions.length}
+  <div class="transmissions-list">
+    <h2 class="fr-h5">{data.transmissions.length} transmission(s) configurée(s)</h2>
+
+    {#each data.transmissions as transmission}
+      <section class="transmission-panel">
+        <div class="transmission-panel__header">
+          <div>
+            <h3 class="fr-h6 fr-mb-1v">{transmission.distributor.name}</h3>
+            <p class="fr-text--sm fr-mb-0">
+              {#if transmission.scopeType === "ALL"}
+                Périmètre actuel : tous les contacts visibles par l'OFS
+              {:else}
+                Périmètre actuel : INSEE {codes(transmission.inseeCodes) || "-"}
+                · départements {codes(transmission.departementCodes) || "-"}
+              {/if}
+            </p>
+          </div>
+          <span
+            class={`fr-badge ${transmission.isActive ? "fr-badge--success" : "fr-badge--warning"}`}
+          >
+            {transmission.isActive ? "Active" : "Inactive"}
+          </span>
+        </div>
+
+        <form method="POST" action="?/update" class="transmission-form">
+          <input type="hidden" name="transmissionId" value={transmission.id} />
+
+          <div class="fr-grid-row fr-grid-row--gutters">
+            <div class="fr-col-12 fr-col-lg-4">
+              <label class="fr-label" for={`scopeType-${transmission.id}`}>
+                Périmètre de transmission
+              </label>
+              <select
+                class="fr-select"
+                id={`scopeType-${transmission.id}`}
+                name="scopeType"
+                bind:value={editScopeTypeById[transmission.id]}
+              >
+                <option value="ALL">Tous les contacts visibles</option>
+                <option value="GEOGRAPHIC">Codes INSEE ou départements</option>
+              </select>
+            </div>
+
+            <div class="fr-col-12 fr-col-lg-3">
+              <div class="transmission-status">
+                <p class="fr-label fr-mb-1w">Statut de la transmission</p>
+                <div class="fr-checkbox-group fr-mb-0">
+                  <input
+                    id={`isActive-${transmission.id}`}
+                    name="isActive"
+                    type="checkbox"
+                    checked={transmission.isActive}
+                  />
+                  <label class="fr-label" for={`isActive-${transmission.id}`}>
+                    Active
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {#if editScopeTypeById[transmission.id] === "GEOGRAPHIC"}
+            <div class="transmission-scope fr-mt-2w">
+              <div class="fr-grid-row fr-grid-row--gutters">
+                <div class="fr-col-12 fr-col-md-6">
+                  <label class="fr-label" for={`inseeCodes-${transmission.id}`}>
+                    Codes communes INSEE transmis
+                  </label>
+                  <input
+                    class="fr-input"
+                    id={`inseeCodes-${transmission.id}`}
+                    name="inseeCodes"
+                    value={codes(transmission.inseeCodes)}
+                    placeholder="75056, 69123"
+                  />
+                </div>
+                <div class="fr-col-12 fr-col-md-6">
+                  <label class="fr-label" for={`departementCodes-${transmission.id}`}>
+                    Codes départements transmis
+                  </label>
+                  <input
+                    class="fr-input"
+                    id={`departementCodes-${transmission.id}`}
+                    name="departementCodes"
+                    value={codes(transmission.departementCodes)}
+                    placeholder="75, 69"
+                  />
+                </div>
+              </div>
+            </div>
+          {/if}
+
+          <div class="transmission-panel__actions">
+            <button class="fr-btn fr-btn--secondary" type="submit">
+              Enregistrer les modifications
+            </button>
+          </div>
+        </form>
+      </section>
+    {/each}
+  </div>
+{:else}
+  <div class="fr-alert fr-alert--info"><p>Aucune transmission commerciale configurée.</p></div>
+{/if}
+
+<style>
+  .transmissions-list {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .transmission-panel {
+    background: white;
+    border: 1px solid var(--border-default-grey);
+    border-radius: 0.5rem;
+    padding: 1.5rem;
+  }
+
+  .transmission-panel__header {
+    align-items: flex-start;
+    border-bottom: 1px solid var(--border-default-grey);
+    display: flex;
+    gap: 1rem;
+    justify-content: space-between;
+    margin-bottom: 1.5rem;
+    padding-bottom: 1rem;
+  }
+
+  .transmission-form {
+    width: 100%;
+  }
+
+  .transmission-scope {
+    background: var(--background-alt-grey);
+    border-radius: 0.5rem;
+    padding: 1rem;
+  }
+
+  .transmission-status {
+    min-height: 100%;
+  }
+
+  .transmission-panel__actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 1.5rem;
+  }
+
+  @media (max-width: 48em) {
+    .transmission-panel__header {
+      display: block;
+    }
+
+    .transmission-panel__header .fr-badge {
+      margin-top: 0.75rem;
+    }
+
+    .transmission-panel__actions {
+      justify-content: flex-start;
+    }
+  }
+</style>

--- a/apps/ofs-portal/tests/unit/src/lib/server/auth.spec.ts
+++ b/apps/ofs-portal/tests/unit/src/lib/server/auth.spec.ts
@@ -26,6 +26,19 @@ describe("portal auth helpers", () => {
     ).toBe("/ofs/ofs-1");
   });
 
+  it("resolves commercialisateur users to their dashboard", () => {
+    expect(
+      resolvePortalEntry({
+        id: "1",
+        email: "commercialisateur@example.com",
+        roles: ["commercialisateur"],
+        canAccessAllOfss: false,
+        ofss: [],
+        distributor: { id: "distributor-1", name: "Commercialisateur 1" },
+      }),
+    ).toBe("/commercialisateur");
+  });
+
   it("accepts only safe relative portal return targets", () => {
     expect(isSafePortalReturnTo("/ofs/123")).toBe(true);
     expect(isSafePortalReturnTo("https://example.com")).toBe(false);

--- a/docs/prd/commercialisateur-transmissions.md
+++ b/docs/prd/commercialisateur-transmissions.md
@@ -1,0 +1,115 @@
+# PRD: Comptes commercialisateur et transmissions commerciales
+
+Triage label: `needs-triage`
+
+## Problem Statement
+
+Les OFS reçoivent aujourd'hui dans le portail Boris des lignes de contact correspondant à leur périmètre géographique. Certains OFS travaillent avec des commercialisateurs chargés de vendre ou commercialiser des logements BRS, mais Boris ne permet pas encore de leur donner un accès encadré aux contacts transmis.
+
+Le besoin est de créer un profil **Compte commercialisateur** dans le même portail, rattaché à un **Commercialisateur**, afin que les OFS puissent configurer des **Transmissions commerciales** vers des commercialisateurs déjà rattachés à leur OFS. Un commercialisateur doit voir uniquement les lignes de contact qui lui sont transmises, sans obtenir d'accès de gestion à l'OFS.
+
+## Solution
+
+Ajouter le rôle `commercialisateur` au portail existant. Les administrateurs créent les **Commercialisateurs** et leurs **Comptes commercialisateur**, puis maintiennent le rattachement OFS - Commercialisateur existant. Les **Comptes OFS** configurent ensuite leurs **Transmissions commerciales** uniquement vers les **Commercialisateurs** déjà rattachés à l'OFS concerné.
+
+Une **Transmission commerciale** relie exactement un **OFS** et un **Commercialisateur**. Elle est additive, non exclusive, active ou inactive, et possède un **Périmètre de transmission**. Ce périmètre est soit tous les contacts visibles de l'OFS, soit une sélection de codes communes INSEE et/ou de codes départements. La visibilité est calculée au niveau de la **Ligne de contact**, toujours dans le périmètre déjà visible par l'OFS.
+
+Le **Compte commercialisateur** accède au même portail, dans une section dédiée, avec un tableau de bord groupé par OFS. Il peut consulter et exporter les lignes transmises, voir des informations OFS limitées en lecture seule, et gérer son propre **Suivi commercialisateur**, séparé du suivi OFS.
+
+## User Stories
+
+1. As an administrateur, I want to create a commercialisateur, so that OFS can later transmit contact lines to it.
+2. As an administrateur, I want to edit a commercialisateur, so that its identity stays accurate over time.
+3. As an administrateur, I want to create a compte commercialisateur for an existing commercialisateur, so that its users can access the portal.
+4. As an administrateur, I want to assign exactly one commercialisateur to a compte commercialisateur, so that the user's organization context is unambiguous.
+5. As an administrateur, I want user management to support Admin, OFS, and Commercialisateur roles, so that all portal accounts are managed in one place.
+6. As an administrateur, I want OFS and commercialisateur operational accounts to have exactly one role, so that portal entry points and permissions stay simple.
+7. As an administrateur, I want to filter or identify comptes commercialisateur in user management, so that I can support those users.
+8. As an administrateur, I want commercialisateur accounts to keep using password reset and active/inactive account controls, so that account lifecycle behavior remains consistent.
+9. As a compte commercialisateur, I want to log into the existing portal, so that I do not need a separate application.
+10. As a compte commercialisateur, I want to reach a commercialisateur-specific dashboard after login, so that I only see the features relevant to my profile.
+11. As a compte commercialisateur with no active transmissions, I want to log in and see an empty dashboard state, so that account creation can happen before OFS configuration.
+12. As a compte OFS, I want to configure transmissions commerciales for every OFS I can access, so that I can manage lead transmission for my organizations.
+13. As a compte OFS, I want to select one of the commercialisateurs already linked to the OFS when creating a transmission commerciale, so that transmissions stay aligned with the OFS-commercialisateur relationship managed by admins.
+14. As a compte OFS, I want to create at most one transmission commerciale per commercialisateur for an OFS, so that the relationship has a single editable configuration.
+15. As a compte OFS, I want to choose whether a transmission covers all OFS-visible contact lines or a geographic subset, so that the commercialisateur receives the right contacts.
+16. As a compte OFS, I want to configure a geographic subset using INSEE commune codes, so that I can route contacts by commune reliably.
+17. As a compte OFS, I want to configure a geographic subset using department codes, so that I can route contacts over broader territories.
+18. As a compte OFS, I want to mix INSEE commune codes and department codes in the same transmission, so that I can describe practical commercial territories.
+19. As a compte OFS, I want to edit the scope of an existing transmission, so that I can add or remove communes and departments without creating duplicates.
+20. As a compte OFS, I want to deactivate a transmission rather than hard-delete it, so that the historical relationship is preserved while access stops.
+21. As a compte OFS, I want inactive transmissions to remove commercialisateur visibility immediately, so that access can be stopped safely.
+22. As a compte OFS, I want contact-line visibility to be computed from the current active scope, so that updates apply consistently to old and new contact lines.
+23. As a compte OFS, I want the OFS to keep access to all its own contact lines after transmission, so that transmission does not transfer ownership away from the OFS.
+24. As a compte OFS, I want several commercialisateurs to be able to receive the same contact line, so that overlapping commercial partnerships are supported.
+25. As a compte OFS, I want to see which commercialisateurs received a contact line, so that I understand where the contact was transmitted.
+26. As a compte OFS, I want commercialisateur follow-up metadata to remain separate from OFS follow-up metadata, so that my workflow is not overwritten by a commercialisateur.
+27. As a compte OFS, I want transmissions to stay constrained to contact lines already visible to my OFS, so that I cannot accidentally expose contacts outside my OFS scope.
+28. As a compte commercialisateur, I want my dashboard grouped by OFS, so that I can work by partner OFS.
+29. As a compte commercialisateur, I want every OFS with an active transmission to appear even when no lines currently match, so that I understand my active relationships.
+30. As a compte commercialisateur, I do not want inactive transmissions to appear in my dashboard in V1, so that I only see current relationships.
+31. As a compte commercialisateur, I want to view only the lines transmitted to my commercialisateur, so that I respect the OFS-defined perimeter.
+32. As a compte commercialisateur, I want all accounts belonging to my commercialisateur to inherit the same transmitted contact access, so that organization-level access is consistent.
+33. As a compte commercialisateur, I want contact-line matching to happen per searched location, so that a household searching several places only exposes matching lines.
+34. As a compte commercialisateur, I want to export transmitted contact lines, so that I can work them in my sales process.
+35. As a compte commercialisateur, I want to manage my own follow-up action and status for a transmitted contact line, so that I can track my commercial work.
+36. As a compte commercialisateur, I want my follow-up metadata to be independent from OFS metadata, so that the OFS and commercialisateur workflows do not conflict.
+37. As a compte commercialisateur, I want to see limited read-only OFS identity and contact details, so that I know which OFS partner a contact belongs to.
+38. As a compte commercialisateur, I do not want to edit OFS profile, territory, users, or transmission configuration, so that I do not gain OFS management access.
+39. As a compte commercialisateur, I want current active transmission scope to control historical and new visibility, so that removed territories disappear from my dashboard.
+40. As a compte commercialisateur, I want my previous follow-up metadata to remain stored if a line later becomes visible again, so that work history can resume without merging it with OFS metadata.
+
+## Implementation Decisions
+
+- Add a `commercialisateur` portal role while keeping existing `Distributor` code naming for the **Commercialisateur** organization.
+- Extend user management so operational portal accounts are single-role in V1.
+- Attach each **Compte commercialisateur** to exactly one **Commercialisateur**.
+- Reuse the existing portal application and authentication flow, with role-specific entry points and sections.
+- Add a **Transmission commerciale** model with one active/inactive relationship per OFS and Commercialisateur pair.
+- Model transmission scope as either all OFS-visible contact lines or selected INSEE commune codes and/or department codes.
+- Compute commercialisateur contact visibility dynamically from current active transmission scope.
+- Match conditional transmission at the **Ligne de contact** level using the location INSEE commune code or department code.
+- Keep transmission constrained by the OFS-visible contact query; transmission cannot widen OFS access.
+- Allow overlapping transmissions so multiple commercialisateurs can see the same line.
+- Add separate **Suivi commercialisateur** metadata keyed to the commercialisateur and contact line, independent from OFS contact metadata.
+- Extend portal APIs to list commercialisateur-accessible OFS, fetch transmitted contact lines, export transmitted contact lines, and update commercialisateur follow-up metadata.
+- Extend OFS portal APIs and UI so OFS users can create, edit, and deactivate transmissions for accessible OFS.
+- Let OFS users select only from commercialisateurs already linked to the OFS; admins remain responsible for creating commercialisateurs, comptes commercialisateur, and OFS-commercialisateur links in V1.
+- Show active transmitted OFS relationships in the commercialisateur dashboard even when zero contact lines match.
+- Hide inactive transmissions from the commercialisateur dashboard in V1.
+- Show read-only transmitted-to commercialisateur information to OFS users on contact lines.
+- Avoid email notification or email forwarding in V1; transmission means dashboard and export visibility only.
+- Do not add audit trail for transmission changes in V1, while leaving the domain open for V2 audit trail.
+
+## Testing Decisions
+
+- Tests should assert externally visible behavior: permissions, returned contact lines, dashboard/API outputs, exports, and metadata separation.
+- Repository/usecase tests should cover the deep module that computes transmitted contact visibility from OFS scope plus transmission scope.
+- Authorization tests should cover role entry behavior for admin, OFS, and commercialisateur accounts.
+- API/e2e tests should follow the existing portal OFS eligibility simulation tests as prior art.
+- User management tests should cover creating and updating commercialisateur users, including exactly-one-commercialisateur assignment.
+- Transmission configuration tests should cover one transmission per OFS/commercialisateur, rejection of unlinked commercialisateurs, active/inactive behavior, all-contact scope, INSEE scope, department scope, and mixed INSEE/department scope.
+- Contact visibility tests should cover overlapping transmissions, multi-location simulations, current-scope recomputation, and the rule that transmission cannot exceed OFS scope.
+- Follow-up metadata tests should prove OFS metadata and commercialisateur metadata do not overwrite each other.
+- Export tests should prove commercialisateur exports include only transmitted contact lines.
+- Portal UI tests should cover commercialisateur dashboard grouping by OFS, empty states, inactive-transmission hiding, and limited read-only OFS details.
+
+## Out of Scope
+
+- Email forwarding or notification to commercialisateurs.
+- Audit trail for transmission configuration changes.
+- OFS-created commercialisateurs or OFS-created comptes commercialisateur.
+- Per-user restrictions inside a commercialisateur.
+- Multi-role OFS plus commercialisateur accounts.
+- Commercialisateur management access to OFS profile, territory, users, or transmissions.
+- Exclusive assignment or ownership transfer of contact lines.
+- Hard deletion of transmissions as the primary domain action.
+- Separate portal application for commercialisateurs.
+- Postal-code based transmission routing in V1.
+
+## Further Notes
+
+- The domain glossary for this feature is captured in `CONTEXT.md`.
+- The normalized routing vocabulary is **INSEE commune code** and **department code**, not postal code.
+- Existing location data stores both postal code and citycode, but citycode is the INSEE code and is the preferred routing key.
+- The issue should be published with the `needs-triage` label when GitHub issue tracker access is available.


### PR DESCRIPTION
- Ajout du rôle `commercialisateur` et du rattachement utilisateur à un commercialisateur.
- Ajout du modèle de `transmission commerciale` entre un OFS et un commercialisateur, avec périmètre global ou géographique.
- Ajout d’un suivi commercialisateur séparé du suivi OFS.
- Ajout des écrans portail pour :
  - gérer les transmissions côté OFS ;
  - consulter et exporter les contacts transmis côté commercialisateur.
- Ajout des endpoints API associés et de la migration TypeORM.
- Documentation du modèle métier dans `CONTEXT.md` et le PRD dédié.